### PR TITLE
Publish meeting schedule + time zone converter

### DIFF
--- a/_minutes/README.md
+++ b/_minutes/README.md
@@ -1,0 +1,23 @@
+# Meetings
+
+The [WebExtensions Community group](https://www.w3.org/community/webextensions/) meets virtually every other week, for one hour.
+See the group's mailing list for [instructions to join the meeting](https://lists.w3.org/Archives/Member/internal-webextensions/2021Jun/0000.html).
+
+To accomodate attendees across the globe, the recurring meeting alternates between two time slots:
+
+* Thursday 8 AM PDT / Thursday 3 PM UTC
+* Thursday 11 PM PDT / Friday 6 AM UTC
+* To convert to your local time zone, see https://everytimezone.com/
+
+After the end of each meeting, meeting notes are published here.
+
+
+## Upcoming meetings
+
+* 2021-07-22 at 11 PM PDT = https://everytimezone.com/?t=60f8b500,708
+* 2021-08-05 at 8 AM PDT = https://everytimezone.com/?t=610b2a00,384
+
+## Past meetings
+
+* 2021-07-08 ([minutes](2021-07-08-wecg.md))
+* 2021-06-24 ([minutes](2021-06-24-wecg.md))


### PR DESCRIPTION
As a follow-up to #37 (https://github.com/w3c/webextensions/blob/main/_minutes/2021-07-08-wecg.md#meeting-notes), here is the schedule of the next meetings. I also included an inclusive time zone converter that is able to convert to dates across the whole globe.