### PR TITLE
Publish minutes of 2021-10-14 meeting

### DIFF
--- a/_minutes/2021-10-14-wecg.md
+++ b/_minutes/2021-10-14-wecg.md
@@ -1,0 +1,115 @@
+# WECG Meetings 2021, Public Notes, Oct 14
+
+ * Chair: Tomislav Jovanovic
+ * Scribes: Rob Wu
+
+Time: 8 AM PDT = https://everytimezone.com/?t=61677300,384
+Call-in details: [WebExtensions CG, 14 October 2021 event](https://www.w3.org/events/meetings/f13adee3-d80c-4348-bc2a-64e006b0db4a/20211014T150000)
+Zoom issues?  ping @robwu (Rob Wu, Mozilla) in [chat](https://github.com/w3c/webextensions/blob/main/CONTRIBUTING.md#joining-chat)
+
+
+## Agenda: [github issues](https://github.com/w3c/webextensions/issues)
+
+ * New issues carried over from last meeting
+   * Queue: Do Mozilla and Google agree on main world script injection vs CSP behavior (and more in general the use cases/issues of scripting.registerContentScripts(), [Issue 103](https://github.com/w3c/webextensions/issues/103))? (Maone) (note from Rob: Giorgio was going to file an issue)
+ * [Document basic file structure #102](https://github.com/w3c/webextensions/pull/102)
+ * Legitimate use cases for blocking webRequest - [dynamic tracking protection #88](https://github.com/w3c/webextensions/issues/88)
+ * [request: allow to retrieve a frameID from an &lt;iframe> element #12](https://github.com/w3c/webextensions/issues/12)
+ * Small update on CSP issues [Carlos Jeurissen]
+ * Does Apple plan to add support for urlFilter matching in the declarativeNetRequest API? [Andrey Meshkov]
+ * Secure communication between the main world scripts and the content script/bgpage [#77](https://github.com/w3c/webextensions/issues/77) [#85](https://github.com/w3c/webextensions/issues/85) [#78](https://github.com/w3c/webextensions/issues/78)
+
+
+## Attendees (sign yourself in)
+
+ 1. Tomislav Jovanovic (Mozilla)
+ 2. Daniel Glazman (Dashlane)
+ 3. Krzysztof Modras (Ghostery)
+ 4. Richard Worth (Capital One)
+ 5. Rob Wu (Mozilla)
+ 6. Jack Works (Sujitech)
+ 7. Carlos Jeurissen (Jeurissen Apps)
+ 8. Alexei (Privacy Badger)
+ 9. Nir Nahum (WalkMe)
+ 10. Giorgio Maone (NoScript)
+ 11. Bradley Cushing (Dashlane)
+ 12. Timothy Hatcher (Apple)
+ 13. Andrey Meshkov (AdGuard)
+ 14. Maxim Topciu (AdGuard)
+ 15. David Li (Google)
+ 16. Mukul Purohit (Microsoft)
+ 17. Oliver Dunk (1Password)
+
+
+## Queue (add yourself at the bottom)
+
+ * It would be good to invite somebody from Google who can speak about Google's MV3 SW plans. (Alexei)
+ * &lt;add your topic and name here>
+
+
+## Meeting notes
+
+Notes:
+
+ * Simeon / Google is absent today; the role of chair has been delegated to Tomislav today.
+ * David Li has joined us to represent Google, mainly to collect questions.
+
+[Issue 103](https://github.com/w3c/webextensions/issues/103): Use cases and features for registerContentScripts
+
+ * [giorgio] This API based on Mozilla's and looks promising. Rather than filing bugs here and there on crbug, it may be useful to standardize the new API across browsers, to facilitate the development of extensions without hacks in a uniform way (as detailed in the issue).
+ * [giorgio] main world injection is being implemented for the dynamic content scripts feature.
+ * [rob] If main world execution is supported, it won't be blocked by e.g. unsafe-eval, but other CSP directives such as img-src would be enforced because the script is indistinguishable from page scripts.
+ * [timothy] Looking at scripting API in Safari and also supporting main world execution, also respective CSP as mentioned above.
+
+[Issue 95](https://github.com/w3c/webextensions/issues/95): content_security_policy.content_scripts
+
+ * [carlos] Has Mozilla implemented this, how does it work with the main world?
+ * [tomislav] As mentioned in the previous point, scripts run in the main world are under the same rules as the web page's CSP.
+ * [rob] Not implemented, we initially went for compatibility but we are willing to introduce content_security_policy for content scripts if needed.
+
+[PR 102](https://github.com/w3c/webextensions/pull/102): Document basic file structure
+
+ * [tomislav] Looks good, also agree with Rob's comment about underscore at https://github.com/w3c/webextensions/pull/102#issuecomment-943306117
+ * [timothy] We do not do anything special with \_ nor \_metadata. Safari does not have any reserved names (other than \_generated_background_page.html).
+ * [rob] Resolution is to accept the PR; The review can be done outside of this meeting.
+ * [carlos] Where would we document details such as reserved names? MDN?
+ * [tomislav] It is possible to add non-normative notes to the document. MDN is a good place for this.
+
+[Issue 88](https://github.com/w3c/webextensions/issues/88): Dynamic data-driven Tracking Protection not possible on Manifest V3
+
+ * [krzysztof] (explains issue as described in the issue) In short, dynamically replaces privacy-sensitive parts of content (path/headers/POST data), using blocking webRequest.
+ * [tomislav] Side note, Firefox does support blocking webRequest, so “not possible on DNR” would be more accurate than “not possible on Manifest V3”. It may also be more productive to suggest a solution rather than just stating that it's not possible.
+ * [timothy] Dynamic rules is 5k in Chrome, Safari does not have it yet, but we'll implement it.
+ * [krzysztof] The lists are too large to fit in a dynamic rule. (explains specific example about replacing identifiable tokens with something else that's privacy-preserving)
+ * [timothy] Acknowledges that some logic cannot be implemented with just DNR.
+ * [david] Krzysztof, could you mention your specific example on Github? Then we can consider better support for dynamic rules to support your use case.
+ * [krzysztof] Can do that, but note that it is just a specific case. There are plenty of other use cases that depend on blocking webRequest.
+
+[Issue 12](https://github.com/w3c/webextensions/issues/12): request: allow to retrieve a frameID from an `<iframe>` element
+
+ * [tomislav] Surprised about Devlin's remark about security issues about leaking frameId to a compromised renderer process. The information is synchronously available, which implies that a compromised renderer can already access the information.
+ * (continue discussion on the issue, waiting for next meeting)
+
+Does Apple plan to add support for urlFilter matching in the declarativeNetRequest API?
+
+ * [andrey] Will Safari support urlFilter in DNR? We have experience with Safari's content blocker (which DNR uses under the hood). Problem with the regexFilter is that the compilation takes quite some time, which is costly when the rules are updated dynamically.
+ * [timothy] DNR is indeed built upon the content blocking feature in WebKit. We're transpiling from DNR's JSON to that internal format with some small tweaks. Unlike Chromium, Safari's filter is regexp-based. urlFilter would also be implemented by compiling it to a regexp.
+ * [andrey] What would be the right way to provide feedback?
+ * [timothy] We are already tracking this.
+ * [andrey] We're not satisfied with the regular expression implementation, from the performance POV.
+ * [rob] I'll present my findings on doing research for implementing DNR in Firefox next week during the AdBlocker Dev Summit (https://adblockerdevsummit.com/).
+
+Secure communication between the main world scripts and the content script/bgpage [#77](https://github.com/w3c/webextensions/issues/77) [#85](https://github.com/w3c/webextensions/issues/85) [#78](https://github.com/w3c/webextensions/issues/78)
+
+ * [andrey] Extensions can inject scripts in the main world, but not securely communicate between the extension (content script/bg) and the script running in the main world.
+ * [tomislav] We have a solution (exportFunction), but not sure if it is a feasible method for other implementations.
+ * [rob] It's very difficult for extensions to maintain a secure channel even when initially provided one when the execution context is shared with the main world. But if we put that aside, and consider the possibility of exposing it, then it would functionally be equivalent to running the script from the extension as a function in the main world, which is passed a handle to an API to communicate with the extension. This should be a value that's only available to the closure of the main world script, and cannot be a global API since that can be tampered with by the web page.
+ * [timothy] Not opposed to implement something like exportFunction if it makes sense, but need more context.
+
+Queue: It would be good to invite somebody from Google who can speak about Google's MV3 SW plans. (Alexei)
+
+ * [alexei] Continuing from previous week (summarized last point); I would like to have a public discussion with the one from Google who decided to replace BG with SW.
+ * [david] I am interested in issues with SW, please share the list of use cases at [issue 72](https://github.com/w3c/webextensions/issues/72) where we aggregate use cases.
+ * [rob] Let's move this point to next meeting, so Simeon is also here to discuss this.
+
+The next meeting will be on [Thursday, October 28th, 8 AM PDT (3 PM UTC)](https://everytimezone.com/?t=6179e800,384).

--- a/_minutes/README.md
+++ b/_minutes/README.md
@@ -11,11 +11,12 @@ After the end of each meeting, meeting notes are published here.
 
 ## Upcoming meetings
 
-* 2021-10-14 at 8 AM PDT = https://everytimezone.com/?t=61677300,384
 * 2021-10-28 at 8 AM PDT = https://everytimezone.com/?t=6179e800,384
+* 2021-11-11 at 8 AM PDT = https://everytimezone.com/?t=618c5d00,384
 
 ## Past meetings
 
+* 2021-10-14 ([minutes](2021-10-14-wecg.md))
 * 2021-09-30 ([minutes](2021-09-30-wecg.md))
 * 2021-09-16 ([minutes](2021-09-16-wecg.md))
 * 2021-09-02 ([minutes](2021-09-02-wecg.md))


### PR DESCRIPTION
Generated from https://docs.google.com/document/d/1QkwhEMtMS67JBUkl_WVPZ4lRSKoWcQNlLJSf_GwSXg8/edit

Instead of manually following #23, I created a program that automatically generates a fixed-up markdown version of the notes. At the next meeting I won't be present to record notes, so this tool should hopefully make it easier for the scribe to record notes in a consistent format.

During this meeting we discussed or mentioned #103, #88, #12, #77, #85, #78, #95, #72 and PR #102.