### PR TITLE
Manifest keys cleanup

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -63,7 +63,6 @@ The following keys must be considered valid:
 * <a href="#key-homepage_url">`homepage_url`</a>: optional
 * <a href="#key-icons">`icons`</a>: optional
 * <a href="#key-optional_permissions">`optional_permissions`</a>: optional
-* <a href="#key-options_page">`options_page`</a>: optional
 * <a href="#key-options_ui">`options_ui`</a>: optional
 * <a href="#key-page_action">`page_action`</a>: optional
 * <a href="#key-permissions">`permissions`</a>: optional
@@ -146,10 +145,6 @@ This key may be present.
 This key may be present.
 
 ### Key `optional_permissions`
-
-This key may be present.
-
-### Key `options_page`
 
 This key may be present.
 

--- a/index.bs
+++ b/index.bs
@@ -50,17 +50,14 @@ The following keys must be considered valid:
 * <a href="#key-version">`version`</a>: required.
 * <a href="#key-default_locale">`default_locale`</a>: required under some conditions.
 * <a href="#key-action">`action`</a>: optional
-* <a href="#key-author">`author`</a>: optional
 * <a href="#key-background">`background`</a>: optional
 * <a href="#key-browser_action">`browser_action`</a>: optional
 * <a href="#key-commands">`commands`</a>: optional
 * <a href="#key-content_scripts">`content_scripts`</a>: optional
 * <a href="#key-content_security_policy">`content_security_policy`</a>: optional
 * <a href="#key-description">`description`</a>: optional
-* <a href="#key-developer">`developer`</a>: optional
 * <a href="#key-devtools_page">`devtools_page`</a>: optional
 * <a href="#key-externally_connectable">`externally_connectable`</a>: optional
-* <a href="#key-homepage_url">`homepage_url`</a>: optional
 * <a href="#key-icons">`icons`</a>: optional
 * <a href="#key-optional_permissions">`optional_permissions`</a>: optional
 * <a href="#key-options_ui">`options_ui`</a>: optional
@@ -96,10 +93,6 @@ This key must be present if the `_locales` subdirectory is present, must be abse
 
 This key may be present.
 
-### Key `author`
-
-This key may be present.
-
 ### Key `background`
 
 This key may be present.
@@ -124,19 +117,11 @@ This key may be present.
 
 This key may be present.
 
-### Key `developer`
-
-This key may be present.
-
 ### Key `devtools_page`
 
 This key may be present.
 
 ### Key `externally_connectable`
-
-This key may be present.
-
-### Key `homepage_url`
 
 This key may be present.
 

--- a/index.bs
+++ b/index.bs
@@ -60,6 +60,8 @@ The following keys must be considered valid:
 * <a href="#key-permissions">`permissions`</a>: optional
 * <a href="#key-short_name">`short_name`</a>: optional
 * <a href="#key-web_accessible_resources">`web_accessible_resources`</a>: optional
+* <a href="#key-devtools_page">`devtools_page`</a>: optional
+* <a href="#key-externally_connectable">`externally_connectable`</a>: optional
 
 ### Key `manifest_version`
 
@@ -122,6 +124,14 @@ The short name of the extension. This value should be used in contexts where <a 
 This key may be present. This property can be localized.
 
 ### Key `web_accessible_resources`
+
+This key may be present.
+
+### Key `externally_connectable`
+
+This key may be present.
+
+### Key `devtools_page`
 
 This key may be present.
 

--- a/index.bs
+++ b/index.bs
@@ -53,8 +53,6 @@ The following keys must be considered valid:
 * <a href="#key-author">`author`</a>: optional
 * <a href="#key-background">`background`</a>: optional
 * <a href="#key-browser_action">`browser_action`</a>: optional
-* <a href="#key-chrome_settings_overrides">`chrome_settings_overrides`</a>: optional
-* <a href="#key-chrome_url_overrides">`chrome_url_overrides`</a>: optional
 * <a href="#key-commands">`commands`</a>: optional
 * <a href="#key-content_scripts">`content_scripts`</a>: optional
 * <a href="#key-content_security_policy">`content_security_policy`</a>: optional
@@ -64,8 +62,6 @@ The following keys must be considered valid:
 * <a href="#key-externally_connectable">`externally_connectable`</a>: optional
 * <a href="#key-homepage_url">`homepage_url`</a>: optional
 * <a href="#key-icons">`icons`</a>: optional
-* <a href="#key-incognito">`incognito`</a>: optional
-* <a href="#key-omnibox">`omnibox`</a>: optional
 * <a href="#key-optional_permissions">`optional_permissions`</a>: optional
 * <a href="#key-options_page">`options_page`</a>: optional
 * <a href="#key-options_ui">`options_ui`</a>: optional
@@ -113,14 +109,6 @@ This key may be present.
 
 This key may be present.
 
-### Key `chrome_settings_overrides`
-
-This key may be present.
-
-### Key `chrome_url_overrides`
-
-This key may be present.
-
 ### Key `commands`
 
 This key may be present.
@@ -154,14 +142,6 @@ This key may be present.
 This key may be present.
 
 ### Key `icons`
-
-This key may be present.
-
-### Key `incognito`
-
-This key may be present.
-
-### Key `omnibox`
 
 This key may be present.
 

--- a/index.bs
+++ b/index.bs
@@ -49,9 +49,7 @@ The following keys must be considered valid:
 * <a href="#key-name">`name`</a>: required.
 * <a href="#key-version">`version`</a>: required.
 * <a href="#key-default_locale">`default_locale`</a>: required under some conditions.
-* <a href="#key-action">`action`</a>: optional
 * <a href="#key-background">`background`</a>: optional
-* <a href="#key-browser_action">`browser_action`</a>: optional
 * <a href="#key-commands">`commands`</a>: optional
 * <a href="#key-content_scripts">`content_scripts`</a>: optional
 * <a href="#key-content_security_policy">`content_security_policy`</a>: optional
@@ -61,10 +59,8 @@ The following keys must be considered valid:
 * <a href="#key-icons">`icons`</a>: optional
 * <a href="#key-optional_permissions">`optional_permissions`</a>: optional
 * <a href="#key-options_ui">`options_ui`</a>: optional
-* <a href="#key-page_action">`page_action`</a>: optional
 * <a href="#key-permissions">`permissions`</a>: optional
 * <a href="#key-short_name">`short_name`</a>: optional
-* <a href="#key-sidebar_action">`sidebar_action`</a>: optional
 * <a href="#key-storage">`storage`</a>: optional
 * <a href="#key-theme">`theme`</a>: optional
 * <a href="#key-user_scripts">`user_scripts`</a>: optional
@@ -89,15 +85,7 @@ This key must be present.
 
 This key must be present if the `_locales` subdirectory is present, must be absent otherwise.
 
-### Key `action`
-
-This key may be present.
-
 ### Key `background`
-
-This key may be present.
-
-### Key `browser_action`
 
 This key may be present.
 
@@ -137,10 +125,6 @@ This key may be present.
 
 This key may be present.
 
-### Key `page_action`
-
-This key may be present.
-
 ### Key `permissions`
 
 This key may be present.
@@ -150,10 +134,6 @@ This key may be present.
 The short name of the extension. This value should be used in contexts where <a href="#key-name">`name`</a> is too long to use in full. If `short_name` is not provided, manifest consumers should use a truncated version of `name`.
 
 This key may be present. This property can be localized.
-
-### Key `sidebar_action`
-
-This key may be present.
 
 ### Key `storage`
 

--- a/index.bs
+++ b/index.bs
@@ -54,17 +54,11 @@ The following keys must be considered valid:
 * <a href="#key-content_scripts">`content_scripts`</a>: optional
 * <a href="#key-content_security_policy">`content_security_policy`</a>: optional
 * <a href="#key-description">`description`</a>: optional
-* <a href="#key-devtools_page">`devtools_page`</a>: optional
-* <a href="#key-externally_connectable">`externally_connectable`</a>: optional
 * <a href="#key-icons">`icons`</a>: optional
 * <a href="#key-optional_permissions">`optional_permissions`</a>: optional
 * <a href="#key-options_ui">`options_ui`</a>: optional
 * <a href="#key-permissions">`permissions`</a>: optional
 * <a href="#key-short_name">`short_name`</a>: optional
-* <a href="#key-storage">`storage`</a>: optional
-* <a href="#key-theme">`theme`</a>: optional
-* <a href="#key-user_scripts">`user_scripts`</a>: optional
-* <a href="#key-version_name">`version_name`</a>: optional
 * <a href="#key-web_accessible_resources">`web_accessible_resources`</a>: optional
 
 ### Key `manifest_version`
@@ -105,14 +99,6 @@ This key may be present.
 
 This key may be present.
 
-### Key `devtools_page`
-
-This key may be present.
-
-### Key `externally_connectable`
-
-This key may be present.
-
 ### Key `icons`
 
 This key may be present.
@@ -134,22 +120,6 @@ This key may be present.
 The short name of the extension. This value should be used in contexts where <a href="#key-name">`name`</a> is too long to use in full. If `short_name` is not provided, manifest consumers should use a truncated version of `name`.
 
 This key may be present. This property can be localized.
-
-### Key `storage`
-
-This key may be present.
-
-### Key `theme`
-
-This key may be present.
-
-### Key `user_scripts`
-
-This key may be present.
-
-### Key `version_name`
-
-This key may be present.
 
 ### Key `web_accessible_resources`
 


### PR DESCRIPTION
To start with a clean slate, this PR removes manifest keys not supported in all browsers and not agreed upon by all vendors. We can then add some of them back once we come to agreements. See https://github.com/w3c/webextensions/issues/121

1) Removal of browser-specific manifest key-names: `chrome_settings_overrides`, `chrome_url_overrides`, `incognito`, `omnibox`. See https://github.com/w3c/webextensions/issues/113
2) Removal of `options_page`. See https://github.com/w3c/webextensions/issues/108
3) Removal of author / developer metadata: `author`, `homepage_url`, `developer`. See: https://github.com/w3c/webextensions/issues/67
4) Removal of action-related keys: `action`, `browser_action`, `page_action`, `sidebar_action`. See: https://github.com/w3c/webextensions/issues/50
5) Removal of keys not supported by all browsers. `version_name`, `user_scripts`, `theme`, `storage`, `externally_connectable`, `devtools_page`. These can be reintroduced even when they are not supported by all browsers. Yet right now it's unknown whether there is an agreement on these by those who didn't implement them (yet).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/carlosjeurissen/webextensions/pull/122.html" title="Last updated on Nov 11, 2021, 5:10 PM UTC (5029fdb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webextensions/122/9df2d5c...carlosjeurissen:5029fdb.html" title="Last updated on Nov 11, 2021, 5:10 PM UTC (5029fdb)">Diff</a>