### PR TITLE
Replace outdated meeting link with calendar list

### DIFF
--- a/_minutes/README.md
+++ b/_minutes/README.md
@@ -1,7 +1,7 @@
 # Meetings
 
 The [WebExtensions Community group](https://www.w3.org/community/webextensions/) meets virtually every other week, for one hour.
-The instructions to join the meeting and agenda are available at https://www.w3.org/events/meetings/7fc25ca5-a50c-498c-82e5-f48fc96e1637.
+The instructions to join the meeting and agenda are available at https://www.w3.org/groups/cg/webextensions/calendar.
 
 * Thursday 8 AM PST (4 PM UTC)
 * To convert to your local time zone, see https://everytimezone.com/


### PR DESCRIPTION
~Also added link to last meeting's notes, and~ replaced the link to a past meeting with the calendar list.

@xeenon Could you update https://www.w3.org/groups/cg/webextensions/calendar so that it's in the PDT time zone? It's currently fixed at 3 PM UTC, but after the summer time ends (last weekend for EU, upcoming weekend for US), the meeting is set to happen at 4 PM UTC instead.

Edit: meeting times have been fixed in #124, so this PR is just to update the old link.