### PR TITLE
Add mock for browser.secureStorage proposal

### DIFF
--- a/proposals/secure-storage-mock.js
+++ b/proposals/secure-storage-mock.js
@@ -6,18 +6,18 @@ if (globalThis.browser?.runtime.id) {
   global = chrome;
 } else {
   throw new Error(
-    "browser.secureStorage polyfill must be run in extension contexts"
+    "browser.secureStorage mock must be run in extension contexts"
   );
 }
 
 if (!global.storage?.local) {
-  throw new Error("Using this polyfill requires the 'storage' permission");
+  throw new Error("Using this mock requires the 'storage' permission");
 }
 
 // Existing browser APIs don't give us access to the system's secure storage,
-// meaning all data in this polyfill is stored in less secure mechanisms.
+// meaning all data in this mock is stored in less secure mechanisms.
 console.warn(
-  "Warning: browser.secureStorage polyfill loaded. This proof of concept stores data insecurely and should not be used in production."
+  "Warning: browser.secureStorage mock loaded. This proof of concept stores data insecurely and should not be used in production."
 );
 
 const RECOGNISED_AUTH_METHODS = [

--- a/proposals/secure-storage-polyfill.js
+++ b/proposals/secure-storage-polyfill.js
@@ -1,9 +1,9 @@
 let global;
 
-if (window.browser?.runtime.id) {
-  global = window.browser;
-} else if (window.chrome?.runtime.id) {
-  global = window.chrome;
+if (globalThis.browser?.runtime.id) {
+  global = browser;
+} else if (globalThis.chrome?.runtime.id) {
+  global = chrome;
 } else {
   throw new Error(
     "browser.secureStorage polyfill must be run in extension contexts"
@@ -87,11 +87,11 @@ const secureStorage = {
 };
 
 // Attach to browser namespace in Firefox/Safari
-if (window.browser?.runtime?.id) {
-  window.browser.secureStorage = secureStorage;
+if (globalThis.browser?.runtime?.id) {
+  browser.secureStorage = secureStorage;
 }
 
 // Attach to chrome namespace in all browsers
-if (window.chrome?.runtime?.id) {
-  window.chrome.secureStorage = secureStorage;
+if (globalThis.chrome?.runtime?.id) {
+  chrome.secureStorage = secureStorage;
 }

--- a/proposals/secure-storage-polyfill.js
+++ b/proposals/secure-storage-polyfill.js
@@ -11,7 +11,7 @@ const RECOGNISED_AUTH_METHODS = [
   "BIOMETRY_FINGERPRINT",
 ];
 
-window.secureStorage = {
+const secureStorage = {
   getInfo: () => {
     return {
       type: "MACOS_KEYCHAIN",
@@ -65,3 +65,19 @@ window.secureStorage = {
     return localStorage.removeItem(id);
   },
 };
+
+let isExtension = false;
+
+if (window.browser?.runtime?.id) {
+  window.browser.secureStorage = secureStorage;
+  isExtension = true;
+}
+
+if (window.chrome?.runtime?.id) {
+  window.chrome.secureStorage = secureStorage;
+  isExtension = true;
+}
+
+if (!isExtension) {
+  window.secureStorage = secureStorage;
+}

--- a/proposals/secure-storage-polyfill.js
+++ b/proposals/secure-storage-polyfill.js
@@ -1,0 +1,67 @@
+// Existing browser APIs don't give us access to the system's secure storage,
+// meaning all data in this polyfill is stored in less secure mechanisms.
+console.warn(
+  "Warning: browser.secureStorage polyfill loaded. This proof of concept stores data insecurely and should not be used in production."
+);
+
+const RECOGNISED_AUTH_METHODS = [
+  "PIN",
+  "PASSWORD",
+  "BIOMETRY_FACE",
+  "BIOMETRY_FINGERPRINT",
+];
+
+window.secureStorage = {
+  getInfo: () => {
+    return {
+      type: "MACOS_KEYCHAIN",
+      availableAuthentication: RECOGNISED_AUTH_METHODS,
+    };
+  },
+  store: (request) => {
+    if (typeof request !== "object")
+      throw new Error("secureStorage.store takes an object");
+
+    const { id, authentication, data } = request;
+
+    if (typeof id !== "string") throw new Error("id must be a string");
+
+    if (typeof authentication !== "undefined") {
+      if (!Array.isArray(authentication))
+        throw new Error("authentication must be an array");
+
+      if (authentication.length === 0)
+        throw new Error("authentication array must be non-empty if present");
+
+      for (const method of authentication) {
+        if (!RECOGNISED_AUTH_METHODS.includes(method)) {
+          throw new Error(`unrecognised auth method: ${method}`);
+        }
+      }
+    }
+
+    if (typeof data !== "string") throw new Error("data must be a string");
+
+    localStorage.setItem(id, data);
+  },
+  retrieve: (request) => {
+    if (typeof request !== "object")
+      throw new Error("secureStorage.retrieve takes an object");
+
+    const { id } = request;
+
+    if (typeof id !== "string") throw new Error("id must be a string");
+
+    return localStorage.getItem(id);
+  },
+  remove: (request) => {
+    if (typeof request !== "object")
+      throw new Error("secureStorage.remove takes an object");
+
+    const { id } = request;
+
+    if (typeof id !== "string") throw new Error("id must be a string");
+
+    return localStorage.removeItem(id);
+  },
+};

--- a/proposals/secure-storage-polyfill.js
+++ b/proposals/secure-storage-polyfill.js
@@ -12,13 +12,13 @@ const RECOGNISED_AUTH_METHODS = [
 ];
 
 const secureStorage = {
-  getInfo: () => {
+  getInfo: async () => {
     return {
       type: "MACOS_KEYCHAIN",
       availableAuthentication: RECOGNISED_AUTH_METHODS,
     };
   },
-  store: (request) => {
+  store: async (request) => {
     if (typeof request !== "object")
       throw new Error("secureStorage.store takes an object");
 
@@ -44,7 +44,7 @@ const secureStorage = {
 
     localStorage.setItem(id, data);
   },
-  retrieve: (request) => {
+  retrieve: async (request) => {
     if (typeof request !== "object")
       throw new Error("secureStorage.retrieve takes an object");
 
@@ -54,7 +54,7 @@ const secureStorage = {
 
     return localStorage.getItem(id);
   },
-  remove: (request) => {
+  remove: async (request) => {
     if (typeof request !== "object")
       throw new Error("secureStorage.remove takes an object");
 

--- a/proposals/secure-storage.md
+++ b/proposals/secure-storage.md
@@ -100,7 +100,7 @@ browser.secureStorage.store({
 });
 ```
 
-The authentication array is optional. If omitted, the secret is available without biometrics but is still stored in the hardware backed location.
+The authentication array is optional. If omitted, the secret is available without the need for any of the recognised auth methods but is still stored in the hardware backed location.
 
 **browser.secureStorage.retrieve**
 

--- a/proposals/secure-storage.md
+++ b/proposals/secure-storage.md
@@ -100,6 +100,8 @@ browser.secureStorage.store({
 });
 ```
 
+The authentication array is optional. If omitted, the secret is available without biometrics but is still stored in the hardware backed location.
+
 **browser.secureStorage.retrieve**
 
 This retrieves the stored data. The browser will only provide it if the user authenticates with one of the allowed mechanisms for this secret, and will throw an error otherwise.

--- a/proposals/secure-storage.md
+++ b/proposals/secure-storage.md
@@ -25,7 +25,7 @@ While all of these APIs support storing keys, only macOS Keychain provides a mec
 
 - **Proposal 1:** The browser provides a way of storing keys exclusively, and simply retrieves these from the system level APIs.
 
-- **Proposal 2:** The browser accepts arbitrary data from an extension. Where possible, this is simply stored using the system level APIs. When the system only provides key storage, the browser transparently generates a key and uses this to encrypt the data.
+- **Proposal 2:** The browser accepts arbitrary data from an extension. Where possible, this is simply stored using the system level APIs. When the system only provides key storage, the browser transparently generates a key and uses this to encrypt the data. A polyfill for this proposal is available [here](secure-storage-polyfill.js).
 
 In both cases data can only be read by the extension that stored it.
 


### PR DESCRIPTION
As suggested in the last meeting, this PR adds a polyfill which shows the expected API behaviour of the browser.secureStorage proposal. This includes the `remove` call added in #183.

For obvious reasons, we can't currently access hardware backed secure storage. As a result, this polyfill uses localStorage and is for proof of concept purposes only.

Resolves #180