### PR TITLE
Add MetaMask to secureStorage interested parties

### DIFF
--- a/proposals/secure-storage.md
+++ b/proposals/secure-storage.md
@@ -122,6 +122,8 @@ The Dashlane browser extension, also a password manager with over 4M weekly acti
 
 The Keeper Security [browser extension](https://chrome.google.com/webstore/detail/keeper%C2%AE-password-manager/bfogiafebfohielmmehodmfbbebbbpei?hl=en&authuser=0) would also immediately use this API for storage of client-side generated encryption keys. Even though a desktop app is optionally provided to users, Keeper does not wish to use native app dependencies for biometric authentication and key storage. Keeper would also prefer to prompt users in the browser extension directly for biometric authentication instead of relying on a desktop app.
 
+The [MetaMask](https://metamask.io/) browser extension, a crypto wallet and a gateway to blockchain applications with over 30 million monthly active users, would also greatly benefit from using this API as a more secure way to store a user's private keys while their wallet is locked. They would also be interested in offering users the choice to use biometrics as a simpler way to unlock their wallet.
+
 We expect that the API would benefit a wide range of extensions, providing value far beyond password management. If you'd like to add your extension, feel free to open a PR.
 
 **Could a web API like WebAuthn cater for this use case?**


### PR DESCRIPTION
Hi! The team at MetaMask, a crypto wallet, would be interested in using
the `secureStorage` API currently in proposal stage. This PR adds our
name to the list.