### PR TITLE
Add host_permissions and optional_host_permissions

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -63,6 +63,10 @@ The following keys must be considered valid:
 * <a href="#key-devtools_page">`devtools_page`</a>: optional
 * <a href="#key-externally_connectable">`externally_connectable`</a>: optional
 
+The following keys must be considered valid in manifest v3:
+* <a href="#key-host_permissions">`host_permissions`</a>: optional
+* <a href="#key-optional_host_permissions">`optional_host_permissions`</a>: optional
+
 ### Key `manifest_version`
 
 This key must be present.
@@ -76,6 +80,22 @@ This key must be present. This property can be localized.
 ### Key `version`
 
 This key must be present.
+
+### Key `permissions`
+
+This key may be present.
+
+### Key `optional_permissions`
+
+This key may be present.
+
+### Key `host_permissions`
+
+This key may be present.
+
+### Key `optional_host_permissions`
+
+This key may be present.
 
 ### Key `default_locale`
 
@@ -105,15 +125,7 @@ This key may be present.
 
 This key may be present.
 
-### Key `optional_permissions`
-
-This key may be present.
-
 ### Key `options_ui`
-
-This key may be present.
-
-### Key `permissions`
 
 This key may be present.
 

--- a/index.bs
+++ b/index.bs
@@ -63,7 +63,8 @@ The following keys must be considered valid:
 * <a href="#key-devtools_page">`devtools_page`</a>: optional
 * <a href="#key-externally_connectable">`externally_connectable`</a>: optional
 
-The following keys must be considered valid in manifest v3:
+The following keys must be considered valid in Manifest V3:
+
 * <a href="#key-host_permissions">`host_permissions`</a>: optional
 * <a href="#key-optional_host_permissions">`optional_host_permissions`</a>: optional
 


### PR DESCRIPTION
As each vendor agreed to add `optional_host_permissions` and thus also `host_permissions` in manifest v3, it's time to add it to this repo.

Background issue about supporting `optional_host_permissions`: https://github.com/w3c/webextensions/issues/119


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/carlosjeurissen/webextensions/pull/221.html" title="Last updated on Jun 1, 2022, 7:02 AM UTC (8c0d835)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webextensions/221/953709d...carlosjeurissen:8c0d835.html" title="Last updated on Jun 1, 2022, 7:02 AM UTC (8c0d835)">Diff</a>