### PR TITLE
Move list of meetings into a collapsible section

### DIFF
--- a/_minutes/README.md
+++ b/_minutes/README.md
@@ -21,6 +21,18 @@ After the end of each meeting, meeting notes are published here.
 * 2022-06-09 ([minutes](2022-06-09-wecg.md))
 * 2022-05-26 ([minutes](2022-05-26-wecg.md))
 * 2022-05-12 ([minutes](2022-05-12-wecg.md))
+
+<details>
+<summary><strong>All past meeting notes</strong></summary>
+
+**2022**
+
+* 2022-07-21 ([minutes](2022-07-21-wecg.md))
+* 2022-07-07 ([minutes](2022-07-07-wecg.md))
+* 2022-06-23 ([minutes](2022-06-23-wecg.md))
+* 2022-06-09 ([minutes](2022-06-09-wecg.md))
+* 2022-05-26 ([minutes](2022-05-26-wecg.md))
+* 2022-05-12 ([minutes](2022-05-12-wecg.md))
 * 2022-04-28 ([minutes](2022-04-28-wecg.md))
 * 2022-04-14 ([minutes](2022-04-14-wecg.md))
 * 2022-03-31 ([minutes](2022-03-31-wecg.md))
@@ -30,6 +42,9 @@ After the end of each meeting, meeting notes are published here.
 * 2022-02-03 ([minutes](2022-02-03-wecg.md))
 * 2022-01-20 ([minutes](2022-01-20-wecg.md))
 * 2022-01-06 ([minutes](2022-01-06-wecg.md))
+
+**2021**
+
 * 2021-12-09 ([minutes](2021-12-09-wecg.md))
 * 2021-11-11 ([minutes](2021-11-11-wecg.md))
 * 2021-10-28 ([minutes](2021-10-28-wecg.md))
@@ -42,3 +57,5 @@ After the end of each meeting, meeting notes are published here.
 * 2021-07-22 ([minutes](2021-07-22-wecg.md))
 * 2021-07-08 ([minutes](2021-07-08-wecg.md))
 * 2021-06-24 ([minutes](2021-06-24-wecg.md))
+
+</details>


### PR DESCRIPTION
This PR aims to make the list of previous meetings on `_minutes/README.md` less overwhelming by breaking flat list of all previous meetings into groups based on the year they occurred and collapsing these groups by default. This keeps the readily available while minimizing the amount of information readers are confronted with when they visit the README. 