### PR TITLE
Setup workflow to add needs-triage label to issues

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,3 @@
+# Add needs triage label to all new issues
+needs-triage:
+  - ""

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,0 +1,15 @@
+name: "Needs Triage"
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  triage:
+    if: github.event.issue.labels[0] == null
+    runs-on: ubuntu-latest
+    steps:
+      - uses: github/issue-labeler@v2.5
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          configuration-path: .github/labeler.yml
+          enable-versioned-regex: 0


### PR DESCRIPTION
This sets up the needs-triage label which we discussed in our last meeting (https://github.com/w3c/webextensions/pull/321).

For now I've set things up to skip any issues created with labels. This may miss some issues, since anyone in the CG can add labels, but it felt better than adding the label to issues which may already be correctly triaged. We can always make this more aggressive in the future.

This is based on https://github.com/github/issue-labeler. That adds tags based on checking issue descriptions against RegEx, so I've just specified an empty string that will match all issues.

I've been testing here which shows it working in practice: https://github.com/oliverdunk/triage-test/issues