### PR TITLE
Publish minutes of 2022-11-24 meeting

### DIFF
--- a/_minutes/2022-11-24-wecg.md
+++ b/_minutes/2022-11-24-wecg.md
@@ -1,0 +1,126 @@
+# WECG Meetings 2022, Public Notes, Nov 24
+
+ * Chair: Tomislav Jovanovic
+ * Scribes: Rob Wu
+
+Time: 8 AM PST = https://everytimezone.com/?t=637eb400,3c0
+Call-in details: [WebExtensions CG, 24th November 2022](https://www.w3.org/events/meetings/d7bbce8f-549f-46ea-b440-ea6902f8707c/20221124T080000)
+Zoom issues? Ping @zombie (Tomislav Jovanovic) in [chat](https://github.com/w3c/webextensions/blob/main/CONTRIBUTING.md#joining-chat)
+
+
+## Agenda: [discussion in #320](https://github.com/w3c/webextensions/issues/320), [github issues](https://github.com/w3c/webextensions/issues)
+
+The meeting will start at 3 minutes after the hour.
+
+ * **Carry-over from previous meetings**
+   * [Tomislav] Userscripts meeting discussion summary?
+   * [Issue 311](https://github.com/w3c/webextensions/issues/311): Ability to unload the background script from SW code [regression from MV2]
+ * **Other new issues**
+   * [Issue 317](https://github.com/w3c/webextensions/issues/317): registerProtocolHandler (protocol_handlers) in extensions
+   * [Issue 318:](https://github.com/w3c/webextensions/issues/318) Adjust the maximum number of static rulesets and enabled rulesets
+   * [Issue 319](https://github.com/w3c/webextensions/issues/319): Increase the maximum number of dynamic rules to 30,000
+   * [Issue 325](https://github.com/w3c/webextensions/issues/325): Popup should not close on file navigation initiated by the popup
+   * [Issue 326](https://github.com/w3c/webextensions/issues/326): Any plans to implement "tab" context menu?
+   * [Issue 328](https://github.com/w3c/webextensions/issues/328): Inconsistency: How should tabs.onUpdated behave with the History API?
+ * **Open discussion queue (add yourself at the bottom)**
+   * [Issue 97](https://github.com/w3c/webextensions/issues/97): Proposal: replacement for deprecated report-uri for content_security_policy (Carlos)
+   * [Issue 274](https://github.com/w3c/webextensions/issues/274): Proposal: i18n.getLanguageDictionary (Carlos)
+ * **Check-in on ongoing issues**
+   * None
+
+
+## Attendees (sign yourself in)
+
+ 1. Rob Wu (Mozilla)
+ 2. Juha-Matti Santala (Mozilla)
+ 3. Giorgio Maone (NoScript, Tor)
+ 4. Maxim Topciu (AdGuard)
+ 5. Dmitriy Seregin (AdGuard)
+ 6. Oliver Dunk (1Password)
+ 7. Benjamin Bruneau (1Password)
+ 8. Carlos Jeurissen (Jeurissen Apps)
+ 9. Jason Waterman (Mozilla)
+ 10. Tomislav Jovanovic (Mozilla)
+ 11. Andrey Meshkov (AdGuard)
+ 12. Mukul Purohit (Microsoft)
+
+
+## Meeting notes
+
+Introduction
+
+ * [rob] Google and Apple representatives are absent today due to a US holiday (Thanksgiving). We are continuing this meeting today to cover some issues that are independent of Google and Apple. All other new topics that haven't been covered will be moved to the agenda of the next meeting.
+ * [tomislav] Per [issue 327](https://github.com/w3c/webextensions/issues/327), the 2022-12-22 meeting will be canceled.
+
+[Tomislav] Userscripts meeting discussion summary?
+
+ * [rob] Meeting notes have been published in [PR 324](https://github.com/w3c/webextensions/pull/324) at https://github.com/w3c/webextensions/blob/main/_minutes/2022-11-15-wecg-userscripts.md.
+ * [rob] Summary: The original goal of the meeting was to review the goals and scope of the user script API design. Google's objective of this effort is to reach feature parity with MV2, and identify the foundations needed for future enhancements.
+
+   The initial API suggestion shared by Simeon was to add a “code” parameter to the scripting.registerContentScripts API to allow execution of strings. I recommended at least introducing a new userscript “world” for security reasons. But even with this, the work in progress API design would not address the needs of user script managers ([background in this comment](https://github.com/w3c/webextensions/issues/279#issuecomment-1309614401)).
+
+   In the design of a user script API, there are roughly two approaches to take: let the browser manage the matching and injection, or let an extension run an all_urls content script that takes care of the injection. User script managers currently do the latter, and when asked, the Tampermonkey dev in the meeting expressed the desire to continue doing this. This reduces the scope of the API design.
+
+   The main blocker for user script managers in MV3 compared to MV2 is the inability to run strings as code in the main world (page's context). In MV2 an inline `<script>` element offered this capability in Chrome, but MV3 has a CSP in content scripts that blocks this. The work-in-progress API fills the gap, not by the “code” parameter, but due to not enforcing a CSP in the userscript world. Instead of working around the limitation via this accidental implementation detail, I proposed to focus on two API aspects: allowing a content script to run a string as code in the main world, and a mechanism for secure cross-world communication.
+
+[Issue 311](https://github.com/w3c/webextensions/issues/311): Ability to unload the background script from SW code [regression from MV2]
+
+ * [tomislav] Reporter stated that event pages/background pages can use window.close(), but service workers cannot.
+ * [tomislav] I'm not opposed to supporting this capability.
+ * [oliver] Use case from 1Password: clear sensitive data from memory by terminating the background script
+ * [rob] Let's revisit this topic next time to gather feedback from Google/Apple.
+
+[Issue 317](https://github.com/w3c/webextensions/issues/317): registerProtocolHandler (protocol_handlers) in extensions
+
+ * [andrey] Would it make sense to do some unification with the web API?
+ * [tomislav] Yes, but let's discuss this with the other representatives next time.
+
+[Issue 318:](https://github.com/w3c/webextensions/issues/318) Adjust the maximum number of static rulesets and enabled rulesets
+
+ * [rob] (Mozilla) supportive of expanding the number of static rulesets.
+ * [dmitriy] Looking forward to hearing from Google's perspective.
+
+[Issue 319](https://github.com/w3c/webextensions/issues/319): Increase the maximum number of dynamic rules to 30,000
+
+ * [andrey] Although Google is not present here, I would like to hear about Mozilla's perspective on this.
+ * [rob] Firefox continues to support blocking webRequest. Where is your interest in Mozilla's perspective on this API coming from?
+ * [andrey] Well, I presume that Mozilla would eventually drop support for blocking webRequest in favor of DNR.
+ * [rob] Mozilla continues to support blocking webRequest. While we implement DNR, there are currently no plans to drop support for blocking webRequest. We are implementing DNR for compatibility and because there are scenarios where a declarative API can fully cover the needs of extensions. We want to offer extension authors the APIs that they need to function optimally.
+
+[Issue 325](https://github.com/w3c/webextensions/issues/325): Popup should not close on file navigation initiated by the popup
+
+ * [tomislav] This is a Firefox bug, not a cross-browser issue.
+
+[Issue 326](https://github.com/w3c/webextensions/issues/326): Any plans to implement "tab" context menu?
+
+ * [rob] Firefox already supports this. Timothy has already expressed support in the issue, Simeon created a crbug as a follow-up.
+
+[Issue 328](https://github.com/w3c/webextensions/issues/328): Inconsistency: How should tabs.onUpdated behave with the History
+
+ * [oliver] Inconsistencies between browsers.
+ * [rob] The webNavigation API already exists to detect history changes: ​​https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/onHistoryStateUpdated. Do you need this?
+ * [oliver] e.g. onBeforeNavigate does not work in Chrome for extension pages. tabs.onUpdated can be used as a work-around. Is Firefox's behavior supported?
+ * [rob] tabs.onUpdated can fire for many different reasons. Without a test case it is difficult to tell whether the observed behavior is directly linked to the signal that you're interested in, or just coincidentally correlated to an unrelated event.
+
+[Issue 97](https://github.com/w3c/webextensions/issues/97): Proposal: replacement for deprecated report-uri for content_security_policy
+
+ * [carlos] Would be nice to get to a decision on this.
+ * [rob] Is this a nice-to-have feature request, or is there a use case that motivates this feature request?
+ * [carlos] report-uri is deprecated, and may be removed.
+ * [tomislav] Note that this would be mainly about CSP violations in extension pages, not in content scripts.
+ * [rob] CSP is well-defined for documents only, not content scripts. If we restrict ourselves to extension pages, then the desired functionality can be achieved without new APIs. report-uri still works today, but if removed, extensions can already use securitypolicyviolation events + fetch to achieve the functionality.
+
+[Issue 274](https://github.com/w3c/webextensions/issues/274): Proposal: i18n.getLanguageDictionary
+
+ * [carlos] Simeon proposed async i18n.getMessage with locale option, but I prefer a i18n.getLanguageDictionary() method in order to have sync getMessage in code.
+ * [rob] The linked feature request ([issue 258](https://github.com/w3c/webextensions/issues/258)) describes a way to update the extension locales at runtime. If this were to be implemented, would you still need the feature as requested here?
+ * [carlos] No.
+ * [andrey] Use case for the dictionary API: localized extension, but not fully localized, so there is some fallback. You want to figure out which ones are not translated, with a dict you'd be able to do that.
+ * [tomislav] What you're describing here is a developer use case, not a user use case.
+ * [andrey] The use case I outlined, is to figure out whether there is enough translated.
+ * [rob] That use case can already be achieved by fetching messages.json for a given language. i18n.getMessage has more features such as fallbacks.
+ * [andrey] True. It would be a convenience.
+ * [tomislav] The discussion with Carlos is about sync vs async getMessage.
+ * [andrey] The use case I described doesn't require sync.
+
+The next meeting will be on [Thursday, December 8th, 8 AM PST (4 PM UTC)](https://everytimezone.com/?t=63912900,3c0).

--- a/_minutes/README.md
+++ b/_minutes/README.md
@@ -10,22 +10,23 @@ After the end of each meeting, meeting notes are published here.
 
 ## Upcoming meetings
 
-- 2022-11-24 at 8 AM PST = https://everytimezone.com/?t=637eb400,3c0
 - 2022-12-08 at 8 AM PST = https://everytimezone.com/?t=63912900,3c0
+- 2023-01-05 at 8 AM PST = https://everytimezone.com/?t=63b61300,3c0
 
 ## Past meetings
 
+* 2022-11-24 ([minutes](2022-11-24-wecg.md))
 * 2022-11-15 User Scripts API kickoff ([minutes](2022-11-15-wecg-userscripts.md))
 * 2022-11-10 ([minutes](2022-11-10-wecg.md))
 * 2022-10-27 ([minutes](2022-10-27-wecg.md))
 * 2022-10-13 ([minutes](2022-10-13-wecg.md))
-* 2022-09-29 ([minutes](2022-09-29-wecg.md))
 
 <details>
 <summary><strong>All past meeting notes</strong></summary>
 
 **2022**
 
+* 2022-11-24 ([minutes](2022-11-24-wecg.md))
 * 2022-11-15 User Scripts API kickoff ([minutes](2022-11-15-wecg-userscripts.md))
 * 2022-11-10 ([minutes](2022-11-10-wecg.md))
 * 2022-10-27 ([minutes](2022-10-27-wecg.md))


### PR DESCRIPTION
Generated from https://docs.google.com/document/d/1QkwhEMtMS67JBUkl_WVPZ4lRSKoWcQNlLJSf_GwSXg8/edit using the tool and process from https://github.com/w3c/webextensions/pull/105.

During this meeting we discussed or mentioned #320, #311, #317, #318, #319, #325, #326, #328, #97, #274, #327, #279, #258. I also summarized the result of the user script meeting (whose notes were published at #324). Many topics were nominated but postponed to the next meeting because the representatives from Google and Apple were absent due to a US holiday (Thanksgiving).