### PR TITLE
Add IDL files for Safari as reference.

### DIFF
--- a/interfaces/safari/WebExtensionAPIAction.idl
+++ b/interfaces/safari/WebExtensionAPIAction.idl
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    MainWorldOnly,
+    NeedsPageWithCallbackHandler,
+    ReturnsPromiseWhenCallbackIsOmitted,
+] interface WebExtensionAPIAction {
+
+    void getTitle([NSDictionary] any details, [Optional, CallbackHandler] function callback);
+    void setTitle([NSDictionary] any details, [Optional, CallbackHandler] function callback);
+
+    void getBadgeText([NSDictionary] any details, [Optional, CallbackHandler] function callback);
+    void setBadgeText([NSDictionary] any details, [Optional, CallbackHandler] function callback);
+
+    void getBadgeBackgroundColor([NSDictionary] any details, [Optional, CallbackHandler] function callback);
+    void setBadgeBackgroundColor([NSDictionary] any details);
+
+    void enable([Optional] double tabIdentifier, [Optional, CallbackHandler] function callback);
+    void disable([Optional] double tabIdentifier, [Optional, CallbackHandler] function callback);
+
+    [NeedsScriptContext, RaisesException] void setIcon(any details, [Optional, CallbackHandler] function callback);
+
+    void getPopup([NSDictionary] any details, [Optional, CallbackHandler] function callback);
+    void setPopup([NSDictionary] any details, [Optional, CallbackHandler] function callback);
+
+    [RaisesException] void openPopup([Optional, NSDictionary] any options, [Optional, CallbackHandler] function callback);
+
+    readonly attribute WebExtensionAPIEvent onClicked;
+
+};

--- a/interfaces/safari/WebExtensionAPIAlarms.idl
+++ b/interfaces/safari/WebExtensionAPIAlarms.idl
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    MainWorldOnly,
+    NeedsPageWithCallbackHandler,
+    ReturnsPromiseWhenCallbackIsOmitted,
+] interface WebExtensionAPIAlarms {
+
+    [ImplementedAs=createAlarm, NeedsFrame] void create([Optional] DOMString name, [NSDictionary] any alarmInfo);
+    [ImplementedAs=getAlarm] void get([Optional] DOMString name, [Optional, CallbackHandler] function callback);
+    [ImplementedAs=getAllAlarms] void getAll([Optional, CallbackHandler] function callback);
+    [ImplementedAs=clearAlarm] void clear([Optional] DOMString name, [Optional, CallbackHandler] function callback);
+    [ImplementedAs=clearAllAlarms] void clearAll([Optional, CallbackHandler] function callback);
+
+    readonly attribute WebExtensionAPIEvent onAlarm;
+
+};

--- a/interfaces/safari/WebExtensionAPICommands.idl
+++ b/interfaces/safari/WebExtensionAPICommands.idl
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    MainWorldOnly,
+    ReturnsPromiseWhenCallbackIsOmitted,
+] interface WebExtensionAPICommands {
+
+    void getAll([Optional, CallbackHandler] function callback);
+
+    readonly attribute WebExtensionAPIEvent onCommand;
+
+};

--- a/interfaces/safari/WebExtensionAPIContextMenus.idl
+++ b/interfaces/safari/WebExtensionAPIContextMenus.idl
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    MainWorldOnly,
+    NeedsPageWithCallbackHandler,
+] interface WebExtensionAPIContextMenus {
+
+    [RaisesException, NeedsScriptContext] any create(any details, [Optional, CallbackHandler] function callback);
+    [ImplementedAs=updateItem, RaisesException, NeedsScriptContext, ReturnsPromiseWhenCallbackIsOmitted] void update([NSObject] any identifier, any details, [Optional, CallbackHandler] function callback);
+    [ImplementedAs=removeItem, RaisesException, ReturnsPromiseWhenCallbackIsOmitted] void remove([NSObject] any identifier, [Optional, CallbackHandler] function callback);
+    [ReturnsPromiseWhenCallbackIsOmitted] void removeAll([Optional, CallbackHandler] function callback);
+
+    readonly attribute WebExtensionAPIEvent onClicked;
+
+    [ImplementedAs=actionMenuTopLevelLimit] readonly attribute double ACTION_MENU_TOP_LEVEL_LIMIT;
+
+};

--- a/interfaces/safari/WebExtensionAPICookies.idl
+++ b/interfaces/safari/WebExtensionAPICookies.idl
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    MainWorldOnly,
+    NeedsPageWithCallbackHandler,
+    ReturnsPromiseWhenCallbackIsOmitted,
+] interface WebExtensionAPICookies {
+
+    [ImplementedAs=getCookie, RaisesException] void get([NSDictionary] any details, [Optional, CallbackHandler] function callback);
+    [ImplementedAs=getAllCookies, RaisesException] void getAll([NSDictionary] any details, [Optional, CallbackHandler] function callback);
+    [ImplementedAs=setCookie, RaisesException] void set([NSDictionary] any details, [Optional, CallbackHandler] function callback);
+    [ImplementedAs=removeCookie, RaisesException] void remove([NSDictionary] any details, [Optional, CallbackHandler] function callback);
+    void getAllCookieStores([Optional, CallbackHandler] function callback);
+
+    readonly attribute WebExtensionAPIEvent onChanged;
+
+};

--- a/interfaces/safari/WebExtensionAPIDeclarativeNetRequest.idl
+++ b/interfaces/safari/WebExtensionAPIDeclarativeNetRequest.idl
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    MainWorldOnly,
+    NeedsPageWithCallbackHandler,
+    ReturnsPromiseWhenCallbackIsOmitted,
+] interface WebExtensionAPIDeclarativeNetRequest {
+
+    [RaisesException] void updateEnabledRulesets([NSDictionary] any options, [Optional, CallbackHandler] function callback);
+    [NeedsFrame] void getEnabledRulesets([Optional, CallbackHandler] function callback);
+
+    [RaisesException] void updateDynamicRules([NSDictionary] any options, [Optional, CallbackHandler] function callback);
+    [NeedsFrame] void getDynamicRules([Optional, CallbackHandler] function callback);
+
+    [RaisesException] void updateSessionRules([NSDictionary] any options, [Optional, CallbackHandler] function callback);
+    [NeedsFrame] void getSessionRules([Optional, CallbackHandler] function callback);
+
+    [RaisesException, NeedsFrame] void getMatchedRules([Optional, NSDictionary] any filter, [Optional, CallbackHandler] function callback);
+
+    [RaisesException] void isRegexSupported([NSDictionary] any regexOptions, [Optional, CallbackHandler] function callback);
+
+    [ImplementedAs=maxNumberOfStaticRulesets] readonly attribute double MAX_NUMBER_OF_STATIC_RULESETS;
+    [ImplementedAs=maxNumberOfEnabledRulesets] readonly attribute double MAX_NUMBER_OF_ENABLED_STATIC_RULESETS;
+
+};

--- a/interfaces/safari/WebExtensionAPIDevTools.idl
+++ b/interfaces/safari/WebExtensionAPIDevTools.idl
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    ReturnsPromiseWhenCallbackIsOmitted,
+] interface WebExtensionAPIDevTools {
+
+    readonly attribute WebExtensionAPIDevToolsInspectedWindow inspectedWindow;
+    readonly attribute WebExtensionAPIDevToolsNetwork network;
+    readonly attribute WebExtensionAPIDevToolsPanels panels;
+
+};

--- a/interfaces/safari/WebExtensionAPIDevToolsElementsPanel.idl
+++ b/interfaces/safari/WebExtensionAPIDevToolsElementsPanel.idl
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    ReturnsPromiseWhenCallbackIsOmitted,
+] interface WebExtensionAPIDevToolsElementsPanel {
+
+    readonly attribute WebExtensionAPIEvent onSelectionChanged;
+
+    [RaisesException] void createSidebarPane(DOMString title, [Optional, CallbackHandler] function callback);
+
+};

--- a/interfaces/safari/WebExtensionAPIDevToolsExtensionPanel.idl
+++ b/interfaces/safari/WebExtensionAPIDevToolsExtensionPanel.idl
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    ReturnsPromiseWhenCallbackIsOmitted,
+] interface WebExtensionAPIDevToolsExtensionPanel {
+
+    readonly attribute WebExtensionAPIEvent onShown;
+    readonly attribute WebExtensionAPIEvent onHidden;
+
+};

--- a/interfaces/safari/WebExtensionAPIDevToolsExtensionSidebarPane.idl
+++ b/interfaces/safari/WebExtensionAPIDevToolsExtensionSidebarPane.idl
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    ReturnsPromiseWhenCallbackIsOmitted,
+] interface WebExtensionAPIDevToolsExtensionSidebarPane {
+
+    [ImplementedAs=setSourceURL, RaisesException] void setPage(DOMString path);
+
+    readonly attribute WebExtensionAPIEvent onShown;
+    readonly attribute WebExtensionAPIEvent onHidden;
+
+    [RaisesException] void setExpression(DOMString expression, [Optional] DOMString rootTitle, [Optional, CallbackHandler] function callback);
+    [RaisesException] void setObject(DOMString jsonObject, [Optional] DOMString rootTitle, [Optional, CallbackHandler] function callback);
+
+};

--- a/interfaces/safari/WebExtensionAPIDevToolsInspectedWindow.idl
+++ b/interfaces/safari/WebExtensionAPIDevToolsInspectedWindow.idl
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    NeedsPageWithCallbackHandler,
+    ReturnsPromiseWhenCallbackIsOmitted,
+] interface WebExtensionAPIDevToolsInspectedWindow {
+
+    [ImplementedAs=evaluateExpression, RaisesException] void eval(DOMString expression, [Optional, NSDictionary] any options, [Optional, CallbackHandler] function callback);
+
+    [RaisesException, NeedsFrame] void reload([Optional, NSDictionary] any options);
+
+    [NeedsFrame] readonly attribute double tabId;
+
+    [RaisesException, Dynamic] void getResources([NSDictionary] any options, [Optional, CallbackHandler] function callback);
+    [Dynamic] readonly attribute WebExtensionAPIEvent onResourceAdded;
+
+};

--- a/interfaces/safari/WebExtensionAPIDevToolsNetwork.idl
+++ b/interfaces/safari/WebExtensionAPIDevToolsNetwork.idl
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    ReturnsPromiseWhenCallbackIsOmitted,
+] interface WebExtensionAPIDevToolsNetwork {
+
+    [RaisesException] void getHAR([Optional, CallbackHandler] function callback);
+
+    readonly attribute WebExtensionAPIEvent onNavigated;
+
+    readonly attribute WebExtensionAPIEvent onRequestFinished;
+
+};

--- a/interfaces/safari/WebExtensionAPIDevToolsPanels.idl
+++ b/interfaces/safari/WebExtensionAPIDevToolsPanels.idl
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    NeedsPageWithCallbackHandler,
+    ReturnsPromiseWhenCallbackIsOmitted,
+] interface WebExtensionAPIDevToolsPanels {
+
+    [ImplementedAs=createNewTab, RaisesException] void create(DOMString title, DOMString iconPath, DOMString pagePath, [Optional, CallbackHandler] function callback);
+
+    readonly attribute WebExtensionAPIDevToolsElementsPanel elements;
+
+    [NeedsFrame] readonly attribute DOMString themeName;
+    readonly attribute WebExtensionAPIEvent onThemeChanged;
+
+};

--- a/interfaces/safari/WebExtensionAPIEvent.idl
+++ b/interfaces/safari/WebExtensionAPIEvent.idl
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    NeedsPageWithCallbackHandler,
+] interface WebExtensionAPIEvent {
+
+    void addListener([CallbackHandler] function listener);
+    void removeListener([CallbackHandler] function listener);
+    boolean hasListener([CallbackHandler] function listener);
+
+};

--- a/interfaces/safari/WebExtensionAPIExtension.idl
+++ b/interfaces/safari/WebExtensionAPIExtension.idl
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    ReturnsPromiseWhenCallbackIsOmitted,
+] interface WebExtensionAPIExtension {
+
+    [URL, ConvertNullStringTo=Null, RaisesException, Dynamic] DOMString getURL(DOMString resourcePath);
+
+    [ImplementedAs=isInIncognitoContext] readonly attribute boolean inIncognitoContext;
+
+    [MainWorldOnly] void isAllowedIncognitoAccess([Optional, CallbackHandler] function callback);
+    [MainWorldOnly] void isAllowedFileSchemeAccess([Optional, CallbackHandler] function callback);
+
+    [MainWorldOnly] any getBackgroundPage();
+    [MainWorldOnly, NeedsScriptContext] any getViews([Optional, NSDictionary] any properties);
+
+};

--- a/interfaces/safari/WebExtensionAPILocalization.idl
+++ b/interfaces/safari/WebExtensionAPILocalization.idl
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    ReturnsPromiseWhenCallbackIsOmitted,
+] interface WebExtensionAPILocalization {
+
+    DOMString getMessage([CannotBeEmpty] DOMString name, [Optional, NSObject] any substitutions);
+
+    DOMString getUILanguage();
+
+    void getAcceptLanguages([Optional, CallbackHandler] function callback);
+
+};

--- a/interfaces/safari/WebExtensionAPINamespace.idl
+++ b/interfaces/safari/WebExtensionAPINamespace.idl
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    ReturnsPromiseWhenCallbackIsOmitted,
+] interface WebExtensionAPINamespace {
+
+    readonly attribute WebExtensionAPIExtension extension;
+
+    readonly attribute WebExtensionAPIRuntime runtime;
+
+    readonly attribute WebExtensionAPILocalization i18n;
+
+    [Dynamic] readonly attribute WebExtensionAPIStorage storage;
+
+    [MainWorldOnly] readonly attribute WebExtensionAPIPermissions permissions;
+
+    [MainWorldOnly] readonly attribute WebExtensionAPITabs tabs;
+
+    [MainWorldOnly] readonly attribute WebExtensionAPIWindows windows;
+
+    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIAction browserAction;
+
+    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIAction pageAction;
+
+    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIAction action;
+
+    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPICommands commands;
+
+    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIContextMenus contextMenus;
+
+    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIContextMenus menus;
+
+    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPINotifications notifications;
+
+    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIAlarms alarms;
+
+    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIWebNavigation webNavigation;
+
+    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIWebRequest webRequest;
+
+    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPICookies cookies;
+
+    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIDeclarativeNetRequest declarativeNetRequest;
+
+    [Dynamic] readonly attribute WebExtensionAPIDevTools devtools;
+
+    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIScripting scripting;
+
+};

--- a/interfaces/safari/WebExtensionAPINotifications.idl
+++ b/interfaces/safari/WebExtensionAPINotifications.idl
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    MainWorldOnly,
+    ReturnsPromiseWhenCallbackIsOmitted,
+] interface WebExtensionAPINotifications {
+
+    readonly attribute WebExtensionAPIEvent onClicked;
+    readonly attribute WebExtensionAPIEvent onButtonClicked;
+
+};

--- a/interfaces/safari/WebExtensionAPIPermissions.idl
+++ b/interfaces/safari/WebExtensionAPIPermissions.idl
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    MainWorldOnly,
+    NeedsPageWithCallbackHandler,
+    ReturnsPromiseWhenCallbackIsOmitted,
+] interface WebExtensionAPIPermissions {
+
+    void getAll([Optional, CallbackHandler] function callback);
+
+    [RaisesException] void contains([NSDictionary] any permissions, [Optional, CallbackHandler] function callback);
+
+    [RaisesException] void request([NSDictionary] any permissions, [Optional, CallbackHandler] function callback);
+
+    [RaisesException] void remove([NSDictionary] any permissions, [Optional, CallbackHandler] function callback);
+
+    readonly attribute WebExtensionAPIEvent onAdded;
+
+    readonly attribute WebExtensionAPIEvent onRemoved;
+
+};

--- a/interfaces/safari/WebExtensionAPIPort.idl
+++ b/interfaces/safari/WebExtensionAPIPort.idl
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+interface WebExtensionAPIPort {
+
+    readonly attribute DOMString name;
+
+    void disconnect();
+
+    readonly attribute WebExtensionAPIEvent onDisconnect;
+
+    readonly attribute WebExtensionAPIEvent onMessage;
+
+    [RaisesException] void postMessage([Serialization=JSON] any message);
+
+    [Dynamic] readonly attribute any sender;
+
+};

--- a/interfaces/safari/WebExtensionAPIRuntime.idl
+++ b/interfaces/safari/WebExtensionAPIRuntime.idl
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    ReturnsPromiseWhenCallbackIsOmitted,
+] interface WebExtensionAPIRuntime {
+
+    [URL, ConvertNullStringTo=Null, RaisesException] DOMString getURL(DOMString resourcePath);
+
+    [NSDictionary] any getManifest();
+
+    [NeedsScriptContext] double getFrameId(any target);
+
+    [NeedsFrame, ProcessArgumentsLeftToRight, RaisesException] void sendMessage([Optional] DOMString extensionId, [Serialization=JSON] any message, [Optional, NSDictionary] any options, [Optional, CallbackHandler] function callback);
+
+    [NeedsFrame] WebExtensionAPIPort connect([Optional] DOMString extensionId, [Optional, NSDictionary] any connectInfo);
+
+    [ImplementedAs=runtimeIdentifier] readonly attribute DOMString id;
+
+    readonly attribute WebExtensionAPIEvent onConnect;
+    readonly attribute WebExtensionAPIEvent onMessage;
+
+    [MainWorldOnly, NeedsFrame] void getBackgroundPage([Optional, CallbackHandler] function callback);
+
+    [MainWorldOnly] void setUninstallURL([URL] DOMString url, [Optional, CallbackHandler] function callback);
+
+    [MainWorldOnly, NeedsFrame] void openOptionsPage([Optional, CallbackHandler] function callback);
+    [MainWorldOnly, NeedsFrame] void reload();
+    [MainWorldOnly] void getPlatformInfo([Optional, CallbackHandler] function callback);
+
+    [MainWorldOnly] readonly attribute WebExtensionAPIEvent onConnectExternal;
+    [MainWorldOnly] readonly attribute WebExtensionAPIEvent onMessageExternal;
+    [MainWorldOnly] readonly attribute WebExtensionAPIEvent onStartup;
+    [MainWorldOnly] readonly attribute WebExtensionAPIEvent onInstalled;
+
+    [MainWorldOnly] readonly attribute any lastError;
+
+    [MainWorldOnly, Dynamic, NeedsFrame] void sendNativeMessage([Optional] DOMString applicationID, [NSObject] any message, [Optional, CallbackHandler] function callback);
+    [MainWorldOnly, Dynamic, NeedsFrame] WebExtensionAPIPort connectNative([Optional] DOMString applicationID);
+
+};

--- a/interfaces/safari/WebExtensionAPIScripting.idl
+++ b/interfaces/safari/WebExtensionAPIScripting.idl
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    MainWorldOnly,
+    NeedsPageWithCallbackHandler,
+    ReturnsPromiseWhenCallbackIsOmitted,
+] interface WebExtensionAPIScripting {
+
+    [RaisesException] void executeScript([NSDictionary] any injectionDetails, [Optional, CallbackHandler] function callback);
+    [RaisesException] void insertCSS([NSDictionary] any injectionDetails, [Optional, CallbackHandler] function callback);
+    [RaisesException] void removeCSS([NSDictionary] any injectionDetails, [Optional, CallbackHandler] function callback);
+    [RaisesException] void registerContentScripts([NSObject] any details, [Optional, CallbackHandler] function callback);
+
+    [RaisesException] void getRegisteredContentScripts([Optional, NSDictionary] any filter, [Optional, CallbackHandler] function callback);
+
+};

--- a/interfaces/safari/WebExtensionAPIStorage.idl
+++ b/interfaces/safari/WebExtensionAPIStorage.idl
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    ReturnsPromiseWhenCallbackIsOmitted,
+] interface WebExtensionAPIStorage {
+
+    readonly attribute WebExtensionAPIStorageArea local;
+    readonly attribute WebExtensionAPIStorageArea sync;
+    readonly attribute WebExtensionAPIStorageArea session;
+
+    readonly attribute WebExtensionAPIEvent onChanged;
+
+};

--- a/interfaces/safari/WebExtensionAPIStorageArea.idl
+++ b/interfaces/safari/WebExtensionAPIStorageArea.idl
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    NeedsPageWithCallbackHandler,
+    ReturnsPromiseWhenCallbackIsOmitted,
+] interface WebExtensionAPIStorageArea {
+
+    [ImplementedAs=getItems, NeedsScriptContext, RaisesException] void get([Optional, NSObject, DOMString] any items, [Optional, CallbackHandler] function callback);
+    [RaisesException] void getBytesInUse([Optional, NSObject, DOMString] any items, [Optional, CallbackHandler] function callback);
+    [ImplementedAs=setItems, NeedsScriptContext, RaisesException] void set([NSDictionary] any items, [Optional, CallbackHandler] function callback);
+    [ImplementedAs=removeItems, RaisesException] void remove([NSObject] any items, [Optional, CallbackHandler] function callback);
+    void clear([Optional, CallbackHandler] function callback);
+
+    readonly attribute WebExtensionAPIEvent onChanged;
+
+    [ImplementedAs=quotaBytes] readonly attribute double QUOTA_BYTES;
+
+    [ImplementedAs=quotaBytesPerItem, Dynamic] readonly attribute double QUOTA_BYTES_PER_ITEM;
+    [ImplementedAs=maxItems, Dynamic] readonly attribute unsigned long MAX_ITEMS;
+    [ImplementedAs=maxWriteOperationsPerHour, Dynamic] readonly attribute unsigned long MAX_WRITE_OPERATIONS_PER_HOUR;
+    [ImplementedAs=maxWriteOperationsPerMinute, Dynamic] readonly attribute unsigned long MAX_WRITE_OPERATIONS_PER_MINUTE;
+};

--- a/interfaces/safari/WebExtensionAPITabs.idl
+++ b/interfaces/safari/WebExtensionAPITabs.idl
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    MainWorldOnly,
+    NeedsPageWithCallbackHandler,
+    ReturnsPromiseWhenCallbackIsOmitted,
+] interface WebExtensionAPITabs {
+
+    [ImplementedAs=createTab, RaisesException] void create([NSDictionary] any properties, [Optional, CallbackHandler] function callback);
+    [ImplementedAs=getTab, RaisesException] void get(double tabID, [Optional, CallbackHandler] function callback);
+    [ImplementedAs=getCurrentTab] void getCurrent([Optional, CallbackHandler] function callback);
+    [ImplementedAs=getSelectedTab, RaisesException, Dynamic] void getSelected([Optional] double windowID, [Optional, CallbackHandler] function callback);
+
+    [ImplementedAs=duplicateTab, RaisesException] void duplicate(double tabID, [Optional, CallbackHandler] function callback);
+    [ImplementedAs=goBackInTab, RaisesException] void goBack([Optional] double tabID, [Optional, CallbackHandler] function callback);
+    [ImplementedAs=goForwardInTab, RaisesException] void goForward([Optional] double tabID, [Optional, CallbackHandler] function callback);
+    [ImplementedAs=queryTabs, RaisesException] void query([NSDictionary] any queryInfo, [Optional, CallbackHandler] function callback);
+    [ImplementedAs=reloadTab, RaisesException] void reload([Optional] double tabID, [Optional, NSDictionary] any reloadProperties, [Optional, CallbackHandler] function callback);
+    [ImplementedAs=closeTabs, RaisesException] void remove([NSObject] any tabIDs, [Optional, CallbackHandler] function callback);
+    [ImplementedAs=updateTab, RaisesException] void update([Optional] double tabID, [NSDictionary] any updateProperties, [Optional, CallbackHandler] function callback);
+
+    [RaisesException] void captureVisibleTab([Optional] double windowID, [Optional, NSDictionary] any options, [Optional, CallbackHandler] function callback);
+
+    [RaisesException] void detectLanguage([Optional] double tabID, [Optional, CallbackHandler] function callback);
+
+    [RaisesException, Dynamic] void executeScript([Optional] double tabID, [NSDictionary] any details, [Optional, CallbackHandler] function callback);
+    [RaisesException, Dynamic] void insertCSS([Optional] double tabID, [NSDictionary] any details, [Optional, CallbackHandler] function callback);
+    [RaisesException, Dynamic] void removeCSS([Optional] double tabID, [NSDictionary] any details, [Optional, CallbackHandler] function callback);
+
+    [RaisesException] void getZoom([Optional] double tabID, [Optional, CallbackHandler] function callback);
+    [RaisesException] void setZoom([Optional] double tabID, double zoomFactor, [Optional, CallbackHandler] function callback);
+
+    [RaisesException] void toggleReaderMode([Optional] double tabID, [Optional, CallbackHandler] function callback);
+
+    [ProcessArgumentsLeftToRight, RaisesException, NeedsFrame] void sendMessage(double tabID, [Serialization=JSON] any message, [Optional, NSDictionary] any options, [Optional, CallbackHandler] function callback);
+    [NeedsFrame] WebExtensionAPIPort connect(double tabID, [Optional, NSDictionary] any connectInfo);
+
+    [ImplementedAs=tabIdentifierNone] readonly attribute double TAB_ID_NONE;
+
+    readonly attribute WebExtensionAPIEvent onActivated;
+    readonly attribute WebExtensionAPIEvent onAttached;
+    readonly attribute WebExtensionAPIEvent onCreated;
+    readonly attribute WebExtensionAPIEvent onDetached;
+    readonly attribute WebExtensionAPIEvent onHighlighted;
+    readonly attribute WebExtensionAPIEvent onMoved;
+    readonly attribute WebExtensionAPIEvent onRemoved;
+    readonly attribute WebExtensionAPIEvent onReplaced;
+    readonly attribute WebExtensionAPIEvent onUpdated;
+
+    [ImplementedAs=discardTab, Dynamic] void discard([Optional] double tabID, [Optional, CallbackHandler] function callback);
+
+    [ImplementedAs=highlightTabs, Dynamic] void highlight([NSDictionary] any highlightInfo, [Optional, CallbackHandler] function callback);
+
+};

--- a/interfaces/safari/WebExtensionAPIWebNavigation.idl
+++ b/interfaces/safari/WebExtensionAPIWebNavigation.idl
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    MainWorldOnly,
+    NeedsPageWithCallbackHandler,
+    ReturnsPromiseWhenCallbackIsOmitted,
+] interface WebExtensionAPIWebNavigation {
+
+    readonly attribute WebExtensionAPIWebNavigationEvent onBeforeNavigate;
+    readonly attribute WebExtensionAPIWebNavigationEvent onCommitted;
+    readonly attribute WebExtensionAPIWebNavigationEvent onDOMContentLoaded;
+    readonly attribute WebExtensionAPIWebNavigationEvent onCompleted;
+    readonly attribute WebExtensionAPIWebNavigationEvent onErrorOccurred;
+
+    [RaisesException] void getFrame([NSDictionary] any details, [Optional, CallbackHandler] function callback);
+    [RaisesException] void getAllFrames([NSDictionary] any details, [Optional, CallbackHandler] function callback);
+
+};

--- a/interfaces/safari/WebExtensionAPIWebNavigationEvent.idl
+++ b/interfaces/safari/WebExtensionAPIWebNavigationEvent.idl
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    MainWorldOnly,
+    NeedsPageWithCallbackHandler,
+] interface WebExtensionAPIWebNavigationEvent {
+
+    [RaisesException] void addListener([CallbackHandler] function listener, [NSDictionary, Optional] any filter);
+    void removeListener([CallbackHandler] function listener);
+    boolean hasListener([CallbackHandler] function listener);
+
+};

--- a/interfaces/safari/WebExtensionAPIWebPageNamespace.idl
+++ b/interfaces/safari/WebExtensionAPIWebPageNamespace.idl
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    ReturnsPromiseWhenCallbackIsOmitted,
+] interface WebExtensionAPIWebPageNamespace {
+
+    readonly attribute WebExtensionAPIWebPageRuntime runtime;
+
+};

--- a/interfaces/safari/WebExtensionAPIWebPageRuntime.idl
+++ b/interfaces/safari/WebExtensionAPIWebPageRuntime.idl
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    ReturnsPromiseWhenCallbackIsOmitted,
+] interface WebExtensionAPIWebPageRuntime {
+
+    [ImplementedAs=sendMessageToExtension, NeedsFrame, ProcessArgumentsLeftToRight, RaisesException] void sendMessage(DOMString extensionId, [Serialization=JSON] any message, [Optional, NSDictionary] any options, [Optional, CallbackHandler] function callback);
+
+    [ImplementedAs=connectToExtension, NeedsFrame] WebExtensionAPIPort connect(DOMString extensionId, [Optional, NSDictionary] any connectInfo);
+
+};

--- a/interfaces/safari/WebExtensionAPIWebRequest.idl
+++ b/interfaces/safari/WebExtensionAPIWebRequest.idl
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    MainWorldOnly,
+    NeedsPageWithCallbackHandler,
+    ReturnsPromiseWhenCallbackIsOmitted,
+] interface WebExtensionAPIWebRequest {
+
+    readonly attribute WebExtensionAPIWebRequestEvent onBeforeRequest;
+    readonly attribute WebExtensionAPIWebRequestEvent onBeforeSendHeaders;
+    readonly attribute WebExtensionAPIWebRequestEvent onSendHeaders;
+    readonly attribute WebExtensionAPIWebRequestEvent onHeadersReceived;
+    readonly attribute WebExtensionAPIWebRequestEvent onAuthRequired;
+    readonly attribute WebExtensionAPIWebRequestEvent onBeforeRedirect;
+    readonly attribute WebExtensionAPIWebRequestEvent onResponseStarted;
+    readonly attribute WebExtensionAPIWebRequestEvent onCompleted;
+    readonly attribute WebExtensionAPIWebRequestEvent onErrorOccurred;
+
+};

--- a/interfaces/safari/WebExtensionAPIWebRequestEvent.idl
+++ b/interfaces/safari/WebExtensionAPIWebRequestEvent.idl
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    MainWorldOnly,
+    NeedsPageWithCallbackHandler,
+] interface WebExtensionAPIWebRequestEvent {
+
+    [RaisesException] void addListener([CallbackHandler] function listener, [NSDictionary] any filter, [NSArray=NSString, Optional] array extraInfoSpec);
+    void removeListener([CallbackHandler] function listener);
+    boolean hasListener([CallbackHandler] function listener);
+
+};

--- a/interfaces/safari/WebExtensionAPIWindows.idl
+++ b/interfaces/safari/WebExtensionAPIWindows.idl
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    MainWorldOnly,
+    NeedsPageWithCallbackHandler,
+    ReturnsPromiseWhenCallbackIsOmitted,
+] interface WebExtensionAPIWindows {
+
+    [ImplementedAs=getWindow, RaisesException] void get(double windowID, [Optional, NSDictionary] any info, [Optional, CallbackHandler] function callback);
+    [ImplementedAs=getCurrentWindow, RaisesException] void getCurrent([Optional, NSDictionary] any info, [Optional, CallbackHandler] function callback);
+    [ImplementedAs=getLastFocusedWindow, RaisesException] void getLastFocused([Optional, NSDictionary] any info, [Optional, CallbackHandler] function callback);
+    [ImplementedAs=getAllWindows, RaisesException] void getAll([Optional, NSDictionary] any info, [Optional, CallbackHandler] function callback);
+
+    [ImplementedAs=createWindow, Dynamic, RaisesException] void create([Optional, NSDictionary] any data, [Optional, CallbackHandler] function callback);
+    [ImplementedAs=updateWindow, Dynamic, RaisesException] void update(double windowID, [NSDictionary] any info, [Optional, CallbackHandler] function callback);
+    [ImplementedAs=closeWindow, Dynamic, RaisesException] void remove(double windowID, [Optional, CallbackHandler] function callback);
+
+    [ImplementedAs=windowIdentifierNone] readonly attribute double WINDOW_ID_NONE;
+    [ImplementedAs=windowIdentifierCurrent] readonly attribute double WINDOW_ID_CURRENT;
+
+    readonly attribute WebExtensionAPIWindowsEvent onCreated;
+    readonly attribute WebExtensionAPIWindowsEvent onRemoved;
+    readonly attribute WebExtensionAPIWindowsEvent onFocusChanged;
+
+};

--- a/interfaces/safari/WebExtensionAPIWindowsEvent.idl
+++ b/interfaces/safari/WebExtensionAPIWindowsEvent.idl
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    MainWorldOnly,
+    NeedsPageWithCallbackHandler,
+] interface WebExtensionAPIWindowsEvent {
+
+    [RaisesException] void addListener([CallbackHandler] function listener, [Optional, NSDictionary] any filter);
+    void removeListener([CallbackHandler] function listener);
+    boolean hasListener([CallbackHandler] function listener);
+
+};


### PR DESCRIPTION
This adds the `interfaces/safari` directory and the IDL files used for the JavaScript interfaces for Web Extensions. These can be used as a reference for specification work and to identify inconsistencies.