### PR TITLE
Don't deploy for changes to _minutes/

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,8 +7,12 @@ on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
     branches: [ main ]
+    paths-ignore:
+      - '_minutes/**'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - '_minutes/**'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
The content of _minutes/ never affects the publication on the gh-pages branch. To avoid unnecessary deploy builds when we publish meeting notes, add `_minutes/**` to the paths to ignore in the deploy workflow.

`paths-ignore` is documented at https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-excluding-paths