### PR TITLE
Add sections from TPAC 2023 draft

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -176,7 +176,7 @@ Issue(62): Specify localization handling.
 
 ### Uniqueness of extension IDs
 
-### Promises & callbacks
+### Promises and callbacks
 
 ### User gestures and activeTab
 

--- a/index.bs
+++ b/index.bs
@@ -11,33 +11,33 @@ Abstract: [Placeholder] Abstract.
 Markup Shorthands: markdown yes
 </pre>
 
-# File structure
+## File structure
 
 Once unpacked from the distribution format, a WebExtension is a directory containing a number of files.
 
 Note: In some operating systems, filenames are case insensitive. This can lead to naming collisions.
 
-## manifest.json
+### manifest.json
 
 A <a href="#manifest">Manifest</a> file.
 
-## _locales subdirectory
+### _locales subdirectory
 
 An optional directory containing strings as defined in <a href="#localization">localization</a>.
 
-## Other files
+### Other files
 
 An extension may also contain other files, such as those referenced in the <a href="#key-content_scripts">content_scripts</a> and <a href="#key-background">background</a> part of the <a href="#manifest">Manifest</a>.
 
-# Manifest
+## Manifest
 
 A WebExtension must have a manifest file at its root directory.
 
-## Manifest file
+### Manifest file
 
 A manifest file is a [[!JSON]] document named `manifest.json`. Malformed JSON files are not supported.
 
-## Manifest keys
+### Manifest keys
 
 If manifest keys that are not defined in this specification are specified, implementors must ignore those keys.
 
@@ -68,88 +68,138 @@ The following keys must be considered valid in Manifest V3:
 * <a href="#key-host_permissions">`host_permissions`</a>: optional
 * <a href="#key-optional_host_permissions">`optional_host_permissions`</a>: optional
 
-### Key `manifest_version`
+#### Key `manifest_version`
 
 This key must be present.
 
-### Key `name`
+#### Key `name`
 
 Name of the extension used in the browser’s user interface. This should be the full name used to identify the extension. See also <a href="#key-short_name">`short_name`</a>.
 
 This key must be present. This property can be localized.
 
-### Key `version`
+#### Key `version`
 
 This key must be present.
 
-### Key `permissions`
+#### Key `permissions`
 
 This key may be present.
 
-### Key `optional_permissions`
+#### Key `optional_permissions`
 
 This key may be present.
 
-### Key `host_permissions`
+#### Key `host_permissions`
 
 This key may be present.
 
-### Key `optional_host_permissions`
+#### Key `optional_host_permissions`
 
 This key may be present.
 
-### Key `default_locale`
+#### Key `default_locale`
 
 This key must be present if the `_locales` subdirectory is present, must be absent otherwise.
 
-### Key `background`
+#### Key `background`
 
 This key may be present.
 
-### Key `commands`
+#### Key `commands`
 
 This key may be present.
 
-### Key `content_scripts`
+#### Key `content_scripts`
 
 This key may be present.
 
-### Key `content_security_policy`
+#### Key `content_security_policy`
 
 This key may be present.
 
-### Key `description`
+#### Key `description`
 
 This key may be present.
 
-### Key `icons`
+#### Key `icons`
 
 This key may be present.
 
-### Key `options_ui`
+#### Key `options_ui`
 
 This key may be present.
 
-### Key `short_name`
+#### Key `short_name`
 
 The short name of the extension. This value should be used in contexts where <a href="#key-name">`name`</a> is too long to use in full. If `short_name` is not provided, manifest consumers should use a truncated version of `name`.
 
 This key may be present. This property can be localized.
 
-### Key `web_accessible_resources`
+#### Key `web_accessible_resources`
 
 This key may be present.
 
-### Key `externally_connectable`
+#### Key `externally_connectable`
 
 This key may be present.
 
-### Key `devtools_page`
+#### Key `devtools_page`
 
 This key may be present.
 
-# Localization
+### Reserved file names
+
+Filenames beginning with an underscore (`_`) are reserved for use by user agent.
+
+## Isolated worlds
+
+## Unavailable APIs
+
+## The `browser` global
+
+## Extension origin
+
+## Localization
 
 The _locales subdirectory of a WebExtension can contain strings for internationalization purposes.
 
 Issue(62): Specify localization handling.
+
+## Host permissions
+
+### Cross-origin fetch
+
+## Match patterns
+
+## Concepts
+
+### Uniqueness of extnsion IDs
+
+### Promises & callbacks
+
+### User gestures and activeTab
+
+### Extension permissions and web perissions
+
+## Content security policy
+
+## Architecture
+
+### Background content
+
+### Content scripts
+
+#### Isolated worlds
+
+### Extension pages
+
+## Classes of security risk
+
+## Web accessible resources
+
+## Interaction with the web
+
+### Current behavior of cookie partitioning
+
+## Version number handling

--- a/index.bs
+++ b/index.bs
@@ -174,7 +174,7 @@ Issue(62): Specify localization handling.
 
 ## Concepts
 
-### Uniqueness of extnsion IDs
+### Uniqueness of extension IDs
 
 ### Promises & callbacks
 


### PR DESCRIPTION
During TPAC 2023 we held a breakout session to discuss what content we should include in the specification draft. That content was captured in [this google doc][1]. This commit migrates the draft spec outline in that document to our spec file.

[1]: https://docs.google.com/document/d/1q9hQgwTVvyujEhvr52ALeTtuYxyzFhQPfRwPg_hBXlI/edit


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webextensions/pull/487.html" title="Last updated on Dec 8, 2023, 4:42 PM UTC (99dafb5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webextensions/487/ba210e9...99dafb5.html" title="Last updated on Dec 8, 2023, 4:42 PM UTC (99dafb5)">Diff</a>