### PR TITLE
Browser-specific needs-triage labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -8,8 +8,3 @@
 "needs-triage: firefox": 
   - ""
 
-"needs-triage%3A safari": 
-  - ""
-
-"needs-triage%3A firefox": 
-  - ""

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,4 +1,4 @@
-# Add a 'needs triage' label for each browser to all new issues
+# Add a 'needs triage' label for each browser engine to all new issues
 "needs-triage: chrome":
   - ""
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,9 @@
-# Add needs triage label to all new issues
-needs-triage:
+# Add a needs triage for each browser to all new issues
+"needs-triage%3A chrome":
+  - ""
+
+"needs-triage%3A safari": 
+  - ""
+
+"needs-triage%3A firefox": 
   - ""

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,4 +1,4 @@
-# Add a needs triage for each browser to all new issues
+# Add a 'needs triage' label for each browser to all new issues
 "needs-triage: chrome":
   - ""
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,11 @@
 # Add a needs triage for each browser to all new issues
-"needs-triage%3A chrome":
+"needs-triage: chrome":
+  - ""
+
+"needs-triage: safari": 
+  - ""
+
+"needs-triage: firefox": 
   - ""
 
 "needs-triage%3A safari": 


### PR DESCRIPTION
Replace the general "needs-triage" label with browser-specific versions of the needs-triage label.