### PR TITLE
Indicate some implementors allow JSON comments in manifest.json

### DIFF
--- a/specification/index.bs
+++ b/specification/index.bs
@@ -35,7 +35,7 @@ A WebExtension must have a manifest file at its root directory.
 
 ### Manifest file
 
-A manifest file is a [[!JSON]] document named `manifest.json`. Malformed JSON files are not supported.
+A manifest file is a [[!JSON]] document named `manifest.json`. Malformed JSON files are not supported. Note that some implementors may accept comments, represented by any content following `//` outside of a JSON string.
 
 ### Manifest keys
 


### PR DESCRIPTION
Update the "Manifest file" section in index.bs to indicate that
some implementors allow comments in the manifest.json file.
(Chromium allows this today.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rdcronin/webextensions/pull/571.html" title="Last updated on Mar 22, 2024, 9:11 PM UTC (1486826)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webextensions/571/1d3d2ad...rdcronin:1486826.html" title="Last updated on Mar 22, 2024, 9:11 PM UTC (1486826)">Diff</a>