### PR TITLE
Add ARTIFACT_NAME to w3c/spec-prod invocation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,8 +28,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - source: ./specification/index.bs
-          - source: ./specification/window.browser.bs
+          - name: specification
+            source: ./specification/index.bs
+          - name: window-browser
+            source: ./specification/window.browser.bs
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -45,3 +47,4 @@ jobs:
           # Deployment will be available at: https://w3c.github.io/webextensions/specification
           SOURCE: ${{ matrix.source }}
           TOOLCHAIN: 'bikeshed'
+          ARTIFACT_NAME: ${{ matrix.name }}


### PR DESCRIPTION
Adds the ARTIFACT_NAME input value to avoid an issue where conflicting artifacts were added and the workflow would fail.

For more context, see the PR I opened here: https://github.com/w3c/spec-prod/pull/180

Relevant release notes: https://github.com/w3c/spec-prod/releases/tag/v2.11.2

Fixes https://github.com/w3c/webextensions/issues/596