### PR TITLE
Fix URL in spec

### DIFF
--- a/specification/index.bs
+++ b/specification/index.bs
@@ -4,7 +4,7 @@ Shortname: webextensions
 Level: 1
 Status: w3c/CG-DRAFT
 Group: WECG
-URL: https://w3c.github.io/webextensions
+URL: https://w3c.github.io/webextensions/specification/index.html
 Editor: Mukul Purohit, Microsoft Corporation https://www.microsoft.com, mpurohit@microsoft.com
 Editor: Tomislav Jovanovic, Mozilla https://www.mozilla.org/, tjovanovic@mozilla.com
 Abstract: [Placeholder] Abstract.


### PR DESCRIPTION
I noticed the URL in the spec points to a 404, so this just fixes that.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lukewarlow/webextensions/pull/652.html" title="Last updated on Jul 3, 2024, 5:28 PM UTC (df6d275)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webextensions/652/2449c71...lukewarlow:df6d275.html" title="Last updated on Jul 3, 2024, 5:28 PM UTC (df6d275)">Diff</a>