### PR TITLE
Use latest Ubuntu version for GitHub deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
   main:
     name: Build, Validate, and Deploy
     # The type of runner that the job will run on
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:


### PR DESCRIPTION
Our deploy workflow was failing because it was using an older version of Ubuntu (which in turn had an older version of Python). Update our YML configuration to use the latest version.

I considered pinning to a newer version but this matches both our other workflows and the w3c/spec-prod repo [1] so seems like a better choice.

I tested the change here: https://github.com/oliverdunk/webextensions/actions/runs/13080342576

[1] https://github.com/w3c/spec-prod/blob/main/.github/workflows/docs.yml