### PR TITLE
Update specification for loading web extensions in WebDriver Classic

### DIFF
--- a/specification/webdriver-classic.bs
+++ b/specification/webdriver-classic.bs
@@ -120,10 +120,11 @@ Repository: w3c/webextensions
                       <a href="https://w3c.github.io/webdriver/#dfn-error">error</a>
                       with <a href="https://w3c.github.io/webdriver/#dfn-error">
                       error code</a> unsupported operation.
-              <li type='a'><p>Let <var>value</var> be the result of
-                      getting the property"<code>value</code>" from
-                      <var>parameters</var>. If <var>value</var> is
-                      <code>null</code>, return
+             <li type='a'><p>If <var>type hint</var> is "base64", let <var>value</var>
+                      be the result of getting the property "<code>value</code>" from
+                      <var>parameters</var>. If <var>type hint</var> is "path" or "archivePath",
+                      let <var>value</var> be the result of getting the property "<code>path</code>" from
+                      <var>parameters</var>. If <var>value</var> is <code>null</code>, return
                       <a href="https://w3c.github.io/webdriver/#dfn-error">error</a>
                       with <a href="https://w3c.github.io/webdriver/#dfn-error">
                       error code</a> invalid argument.


### PR DESCRIPTION
As specified in the BiDi spec, the resource for "path" and "archivePath" should be held in parameters["path"] and "base64" should be in parameters["value"].

https://www.w3.org/TR/webdriver-bidi/#command-webExtension-install