### PR TITLE
Add webdriver-classic.bs to the specs published on GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,8 @@ jobs:
         include:
           - name: specification
             source: ./specification/index.bs
+          - name: webdriver-classic
+            source: ./specification/webdriver-classic.bs
           - name: window-browser
             source: ./specification/window.browser.bs
 

--- a/specification/webdriver-classic.bs
+++ b/specification/webdriver-classic.bs
@@ -109,29 +109,29 @@ Repository: w3c/webextensions
            unsupported operation.
           <li><p>Let <var>type hint</var> be the result of getting the
           property "<code>type</code>" from <var>parameters</var>.
-            <ol>
-              <li type='a'><p> If <var>type hint</var> does not have the value of
+            <ol style="list-style-type: lower-latin">
+              <li><p> If <var>type hint</var> does not have the value of
                       "path", "archivePath", or "base64", return
                       <a href="https://w3c.github.io/webdriver/#dfn-error">error</a>
                       with <a href="https://w3c.github.io/webdriver/#dfn-error">
                       error code</a> invalid argument.
-              <li type='a'><p>If the implementation does not support loading web
+              <li><p>If the implementation does not support loading web
                       extensions using <var>type hint</var>, return
                       <a href="https://w3c.github.io/webdriver/#dfn-error">error</a>
                       with <a href="https://w3c.github.io/webdriver/#dfn-error">
                       error code</a> unsupported operation.
-              <li type='a'><p>Let <var>value</var> be the result of
+              <li><p>Let <var>value</var> be the result of
                       getting the property"<code>value</code>" from
                       <var>parameters</var>. If <var>value</var> is
                       <code>null</code>, return
                       <a href="https://w3c.github.io/webdriver/#dfn-error">error</a>
                       with <a href="https://w3c.github.io/webdriver/#dfn-error">
                       error code</a> invalid argument.
-              <li type='a'><p>If <var>type hint</var> has the value "path" and the
+              <li><p>If <var>type hint</var> has the value "path" and the
                       implementation supports loading a web extension given a
                       path to it's resources, the implementation should load the
                       extension located at the path stored in "<code>value</code>".
-              <li type='a'><p>If <var>type hint</var> has the value "archivePath"
+              <li><p>If <var>type hint</var> has the value "archivePath"
                       and the implementation supports loading a web extension
                       given a path to a ZIP of it's resources, the implementation
                       should extract the ZIP and load the extension located at
@@ -139,7 +139,7 @@ Repository: w3c/webextensions
                       fails, return <a href="https://w3c.github.io/webdriver/#dfn-error">
                       error</a> with <a href="https://w3c.github.io/webdriver/#dfn-error">
                       error code</a> unable to load extension.
-              <li type='a'><p>If <var>type hint</var> has the value "base64" and the
+              <li><p>If <var>type hint</var> has the value "base64" and the
                       implementation supports loading a web extension given a
                       Base64 encoded string of the ZIP representation of the
                       extension's resources, the implementation should extract


### PR DESCRIPTION
https://github.com/w3c/webextensions/pull/760 added this, but we should also publish the built spec.
