### PR TITLE
Publish minutes of 2025-02-27 meeting

### DIFF
--- a/_minutes/2025-02-27-wecg.md
+++ b/_minutes/2025-02-27-wecg.md
@@ -1,0 +1,143 @@
+# WECG Meetings 2025, Public Notes, Feb 27
+
+ * Chair: Timothy Hatcher
+ * Scribes: Rob Wu
+
+Time: 8 AM PST = https://everytimezone.com/?t=67bfab00,384
+Call-in details: [WebExtensions CG, 27th February 2025](https://www.w3.org/events/meetings/0090c842-271b-4194-b93e-9d401d07af5e/20250227T080000/)
+Zoom issues? Ping @zombie (Tomislav Jovanovic) in [chat](https://github.com/w3c/webextensions/blob/main/CONTRIBUTING.md#joining-chat)
+
+
+## Agenda: [discussion in #766](https://github.com/w3c/webextensions/issues/766), [github issues](https://github.com/w3c/webextensions/issues)
+
+The meeting will start at 3 minutes after the hour.
+
+See [issue 531](https://github.com/w3c/webextensions/issues/531) for an explanation of this agenda format.
+
+ * **Announcements** (2 minutes)
+   * Berlin Meeting
+     * Reminder ([Issue 759](https://github.com/w3c/webextensions/issues/759), [wiki](https://github.com/w3c/webextensions/wiki/2025-Berlin-F2F-Coordination), [sign up form](https://docs.google.com/forms/d/e/1FAIpQLSfTc7PjwQhb7Gzt7Damtf5T_UmnhqLpz3M2OR1PfBtWvQbwoQ/viewform))
+     * State of the Browsers / Extensions
+   * Safari Updates
+ * **Triage** (15 minutes)
+   * [Issue 769](https://github.com/w3c/webextensions/issues/769): Proposal: improve tabs.query API when unexpected property is used
+   * [Issue 770](https://github.com/w3c/webextensions/issues/770): Proposal: Perform additional normalization on input URLs to the declarativeNetRequest API
+ * **Timely issues** (10 minutes)
+   * [PR 767](https://github.com/w3c/webextensions/pull/767): Update specification for loading web extensions in WebDriver Classic
+   * [wpt/pull/50648](https://github.com/web-platform-tests/wpt/pull/50648/files): Add the ability to load and test web extensions.
+ * **Check-in on existing issues** (12 minutes)
+
+
+## Attendees (sign yourself in)
+
+ 1. David Johnson (Apple)
+ 2. Rob Wu (Mozilla)
+ 3. Tomislav Jovanovic (Mozilla)
+ 4. Philippe Le Hegaret (W3C)
+ 5. Oliver Dunk (Google)
+ 6. Mukul Purohit (Microsoft)
+ 7. Krzysztof Modras (Ghostery)
+ 8. Timothy Hatcher (Apple)
+ 9. Giorgio Maone (Tor, NoScript)
+ 10. Kiara Rose (Apple)
+ 11. Carlos Jeurissen (Jeurissen Apps)
+ 12. Jordan Spivack (Capital One)
+ 13. Casey Garland (Capital One)
+ 14. Simeon Vincent (Mozilla)
+ 15. Aaron Selya (Google)
+
+
+## Meeting notes
+
+(pre start of the meeting)
+
+ * (Philippe offering help; discussion on logistics, CG→WG and mention of upcoming Berlin meeting where this topic will be covered)
+
+Announcement: Berlin Meeting
+
+ * [timothy] Reminder ([Issue 759](https://github.com/w3c/webextensions/issues/759)) - March 25 - 28 face-to-face meeting in Berlin. Simeon and Timothy discussed last week what we wanted to cover; One of the ideas is a 15-minute mini-presentation from each browser, on the State of the Browsers / Extensions. What's new in the extension ecosystem in the last 6 months since we talked. And since there are multiple extension developer, allow extension developers to chat about pain points, what's new in their extension, etc.
+ * [simeon] I'll prepare a wiki page for the Berlin face-to-face 2025, which will contain the primary information, agenda, etc.
+ * [simeon] I'll also prepare a sign-up form for logistics. Physical space is limited, so we may need to decline some requests to join.
+ * [oliver] Some of the community members join near the end of the week, so would be nice to account for that.
+
+Announcement: Safari Updates
+
+ * [timothy] Safari 18.4 beta just went out. Two new features for macOS: We added the ability to install temporary extensions. You can drag a manifest folder or file into Safari, which allows temporary extensions for testing. There is also a button in the developer settings to allow a file picker to select from disk. You can also distribute Safari Web Extensions outside the App Store if they have been notarized.
+ * [rob] Is there a blog post or something I can link from the meeting notes?
+ * [david] [Temporarily install a web extension folder in macOS Safari](https://developer.apple.com/documentation/safariservices/running-your-safari-web-extension?language=objc#Temporarily-install-a-web-extension-folder-in-macOS-Safari)
+ * [david] [Distribute your Developer ID–signed and notarized extension outside the Mac App Store](https://developer.apple.com/documentation/safariservices/distributing-your-safari-web-extension?language=objc#Distribute-your-Developer-ID-signed-and-notarized-extension-outside-the-Mac-App-Store)
+ * [simeon] Is an Apple Developer Account required for participation in the notarization process?
+ * [timothy] Yes.
+
+[Issue 769](https://github.com/w3c/webextensions/issues/769): Proposal: improve tabs.query API when unexpected property is used
+
+ * [timothy] We ignore unknown properties and don't throw. This is probably something we should change, and I'll get a bug filed for this. Especially for a query() API this is not ideal behavior.
+ * [oliver] The issue mentions that the alternatives are also trade-offs that are not necessarily better. E.g. returning tabs that does not have the unrecognized property may be unexpected.
+ * [timothy] Agreed. E.g. if an extension queries pinned tabs, and pinned tabs are not supported, then an extension could retrieve all tabs and unexpectedly do strange stuff to all tabs.
+ * [timothy] Carlos also pointed out that this was discussed during the San Diego meeting last year.
+ * [rob] That topic was about feature detection. In this case, query() is read-only, so an extension could try catching errors and omitting properties until they encounter a supported set of properties.
+ * [patrick] Context here is frozen tabs, would it make sense to return an empty list by default since there are no frozen tabs?
+ * [rob] That works for properties that are false by default, but not otherwise. Throwing would still make most sense because extensions can detect the situation and handle it.
+ * [patrick] Maybe some sort of strict mode? Throwing like we do today, and otherwise logging a warning in the console.
+ * [krzysztof] As an extension developer, feature detection is important. Also to prepare for upcoming features. Having any way to detect feature support is needed, and currently catching errors is the only way to do that.
+ * [simeon] For the use case that Patrick is describing, would an opt-in like silence errors be useful?
+ * [patrick] As a developer coming to extensions world, this seems weird to me, since I would expect errors to be an opt-in. I know we discussed a kind of supports() idea before.
+ * [simeon] That was the direction we were going with at TPAC.
+ * [timothy] Designing a general mechanism is tricky for us in the implementation.
+ * [] We need some standard-ish way to identify methods.
+ * [tomislav] The MDN documentation has some structured data.
+ * [timothy] It needs to be something we do as an API.
+ * [rob] Every implementation knows which methods and properties it recognizes; exposing just that information is already helpful and would address the use case from this issue.
+ * [patrick] Some APIs have enums.
+ * [krzysztof] The detection mechanism should be synchronous. E.g. there is currently no way to detect availability of the blocking webRequest feature in Chrome.
+ * [oliver] Wondering whether `management.getSelf()` could be synchronous to allow extensions to detect policy-installed extensions.
+   * (context: in Chrome's MV3, extensions cannot use blocking webRequests, except for policy-installed extensions)
+ * [rob] Let's save that discussion for later. There is implementation complexity involved in making async APIs synchronous.
+
+[Issue 770](https://github.com/w3c/webextensions/issues/770): Proposal: Perform additional normalization on input URLs to the declarativeNetRequest API
+
+ * [oliver] I opened this on behalf of Martin.
+ * [martin] This came up in Chrome, where we worked on the internal implementation of DNR. What I am proposing is to remove trailing periods from fully-qualified domain names, and to also percent-decode additional characters, such as slashes. Wondering whether this makes sense in the DNR API.
+ * [rob] Can you enumerate the normalizations you have in mind?  Fully qualified domain names (FQDN) are not directly equivalent to the URL with the trailing period stripped. Chrome treats them as equivalent in the extension APIs, Firefox considers them different, because servers can treat them differently.
+ * [oliver] For the use case of blocking, if the intent is to block `example.com`, then `example.com.` should probably be blocked too.
+ * [krzysztof] Normalization is just part of the issue, we lack tooling to detect issues. Normalization would make it harder for developers to debug issues.
+ * [krzysztof] As content blockers, we have to account for rules from many other community members. Some browsers have normalization, some don't, etc.
+ * [rob] Is Google thinking of making this the only behavior, or an opt-in/opt-out?
+ * [martin] We could make it optional.
+ * [rob] And the next question is, what should be the default behavior?
+ * [alexei] If you think of the case where an extension wants to disable it from the site, we might register an allowAllRequests rule with DNR, update our scripts/scripting API to toggle all scripts, and have our own “disable” logic. If browsers make a change to how the DNR API functions, then would there be a difference between how DNR works and match patterns work?
+ * [rob] In this case, urlFilter is DNR-specific. Match patterns are already normalized in Chrome, FQDN are separate from non-FQDN match patterns in Firefox.
+ * [timothy] Concerns about inconsistencies. Should be specified for interoperability.
+ * [oliver] Willing to accept the changes to urlFilter?
+ * [rob] Willing to consider normalization, if specified properly and if extension developer use cases are covered.
+ * [timothy] Agreed on need to be precise. Issue speaks about GURL(), we implement things differently.
+ * [oliver] Action item for us to be more precise.
+
+[PR 767](https://github.com/w3c/webextensions/pull/767): Update specification for loading web extensions in WebDriver Classic
+
+ * [kiara] Updated PR to put archivePath and base64 in a format to match the bidi spec.
+ * [timothy] Tomislav has approved, should be good to merge.
+
+[wpt/pull/50648](https://github.com/web-platform-tests/wpt/pull/50648/files): Add the ability to load and test web extensions.
+
+ * [timothy] Lots of back and forth here.
+ * [tomislav] We have had discussions with wpt folks etc where the logic should live; I am not interested in that path, but I am interested in the actual API exposed to tests (browser.test exposed to extensions) and page that is running the test.
+ * [tomislav] In the current proposal, browser.test.assertTrue (etc.) functions forward the assertions to the test runner. Should We specify that they throw?
+ * [rob] In Firefox, browser.test.assertTrue, etc. do not throw in Firefox.
+ * [timothy] In Safari, they don't throw either.
+ * [oliver] I'll have to check what Chrome does.
+ * [tomislav] And then we should specify that.
+ * [tomislav] In Firefox we have an utility that allows the test runner to communicate with the extension. We could either update all methods to take an extension ID, or return an object/handle that allows methods to be associated with an extension instance.
+ * [krzysztof] Doesn't that belong to the webdriver spec?
+ * [rob] Just to make sure that we are all on the same page: Krzysztof is talking about the protocol, but Tomislav is talking about the higher level API exposed to the tests themselves.
+ * [tomislav] That is right.
+ * [tomislav] Example of loadExtension returning an “extension” wrapper that offers sendMessage etc, https://searchfox.org/mozilla-central/rev/80ae03d93e/browser/components/extensions/test/browser/browser_ext_tabs_executeScript_good.js#29-45,47-48,54,56,62
+ * [timothy] I can see that working, but wonder whether there are issues between mixing wpt and browser test APIs.
+ * [tomislav] It is part of the machinery to run tests, but not part of the RFC.
+ * [kiara] I can add that.
+ * [timothy] Multiple extensions are currently not handled well. We either need an extension ID to be included in the message (sending and receiving). A live object is a possibility too.
+ * [krzysztof] Why is the browser.test namespace used?
+ * [rob] All browsers here already use browser.test, using that same namespace eases porting of existing tests to wpt.
+ * [timothy] Another reason is that including the test harness everywhere in the extension is complicated, which would require lots of boilerplate.
+
+The next meeting will be on [Thursday, March 13th, 8 AM PDT (3 PM UTC)](https://everytimezone.com/?t=67d22000,384). Warning: Daylight saving time changed in the US. Meeting time is now at 3 PM UTC instead of 4 PM UTC.

--- a/_minutes/README.md
+++ b/_minutes/README.md
@@ -3,30 +3,31 @@
 The [WebExtensions Community group](https://www.w3.org/community/webextensions/) meets virtually every other week, for one hour.
 The instructions to join the meeting and agenda are available at https://www.w3.org/groups/cg/webextensions/calendar.
 
-* Thursday 8 AM PST (3 PM UTC)
+* Thursday 8 AM PDT (3 PM UTC)
 * To convert to your local time zone, see https://everytimezone.com/
 
 After the end of each meeting, meeting notes are published here.
 
 ## Upcoming meetings
 
-- 2025-02-27 at 8 AM PST = https://everytimezone.com/?t=67bfab00,384
-- 2025-03-13 at 8 AM PST = https://everytimezone.com/?t=67d22000,384
+- 2025-03-13 at 8 AM PDT = https://everytimezone.com/?t=67d22000,384
+- 2025-03-27 at 8 AM PDT = https://everytimezone.com/?t=67e49500,384
 
 ## Past meetings
 
+* 2025-02-27 ([minutes](2025-02-27-wecg.md))
 * 2025-02-13 ([minutes](2025-02-13-wecg.md))
 * 2025-01-30 ([minutes](2025-01-30-wecg.md))
 * 2025-01-16 ([minutes](2025-01-16-wecg.md))
 * 2024-12-19 ([minutes](2024-12-19-wecg.md))
 * 2024-12-05 ([minutes](2024-12-05-wecg.md))
-* 2024-11-21 ([minutes](2024-11-21-wecg.md))
 
 <details>
 <summary><strong>All past meeting notes</strong></summary>
 
 **2025**
 
+* 2025-02-27 ([minutes](2025-02-27-wecg.md))
 * 2025-02-13 ([minutes](2025-02-13-wecg.md))
 * 2025-01-30 ([minutes](2025-01-30-wecg.md))
 * 2025-01-16 ([minutes](2025-01-16-wecg.md))


### PR DESCRIPTION
Generated from https://docs.google.com/document/d/1QkwhEMtMS67JBUkl_WVPZ4lRSKoWcQNlLJSf_GwSXg8/edit using the tool and process from https://github.com/w3c/webextensions/pull/105.

During this meeting we discussed or mentioned issues #766, #531, #759, #769, #770 and PR #767. Safari also announced improvements to testing temporary extensions and distributing them outside the App Store, see the meeting notes for details.

Note: due to the Daylight Saving Time change in the USA (Pacific, PST -> PDT), the next meeting is at 3 PM UTC instead of the usual 4 PM UTC time. For those in central Europe, the meeting schedule will temporarily shift from 5 PM to 4 PM for the next two meetings (13 and 27 March), until Europe also ends the Daylight Saving Time on March 30th.