### PR TITLE
Add `trial_tokens` key to specification

### DIFF
--- a/specification/index.bs
+++ b/specification/index.bs
@@ -149,6 +149,10 @@ This key may be present.
 
 This key may be present.
 
+### Key `trial_tokens`
+
+The <a href="#key-trial_tokens">`trial_tokens`</a> key is an optional [=list=] of strings. These may be used by the user agent to enable experimental features for the [[#extension-origin]]. The user agent may ignore or warn about any unrecognised, expired or malformed keys but must only show a warning and must not prevent the extension from loading.
+
 ## Reserved file names
 
 Filenames beginning with an underscore (`_`) are reserved for use by user agent.

--- a/specification/index.bs
+++ b/specification/index.bs
@@ -151,7 +151,7 @@ This key may be present.
 
 ### Key `trial_tokens`
 
-The <a href="#key-trial_tokens">`trial_tokens`</a> key is an optional [=list=] of strings. These may be used by the user agent to enable experimental features for the [[#extension-origin]]. The user agent may ignore or warn about any unrecognized, expired or malformed keys but must only show a warning and must not prevent the extension from loading.
+The <a href="#key-trial_tokens">`trial_tokens`</a> key is an optional [=list=] of strings. These may be used by the user agent to enable experimental features for the [[#extension-origin]]. The user agent may ignore or warn about any unrecognized, expired or malformed keys but any such entries must not prevent the extension from loading.
 
 ## Reserved file names
 

--- a/specification/index.bs
+++ b/specification/index.bs
@@ -151,7 +151,7 @@ This key may be present.
 
 ### Key `trial_tokens`
 
-The <a href="#key-trial_tokens">`trial_tokens`</a> key is an optional [=list=] of strings. These may be used by the user agent to enable experimental features for the [[#extension-origin]]. The user agent may ignore or warn about any unrecognised, expired or malformed keys but must only show a warning and must not prevent the extension from loading.
+The <a href="#key-trial_tokens">`trial_tokens`</a> key is an optional [=list=] of strings. These may be used by the user agent to enable experimental features for the [[#extension-origin]]. The user agent may ignore or warn about any unrecognized, expired or malformed keys but must only show a warning and must not prevent the extension from loading.
 
 ## Reserved file names
 

--- a/specification/index.bs
+++ b/specification/index.bs
@@ -63,6 +63,7 @@ The following keys must be considered valid:
 * <a href="#key-web_accessible_resources">`web_accessible_resources`</a>: optional
 * <a href="#key-devtools_page">`devtools_page`</a>: optional
 * <a href="#key-externally_connectable">`externally_connectable`</a>: optional
+* <a href="#key-trial_tokens">`trial_tokens`</a>: optional
 
 The following keys must be considered valid in Manifest V3:
 


### PR DESCRIPTION
Adds information on the `trial_tokens` key to the specification, based on the proposal [1]. The proposal is quite in depth but I have kept the specification more limited as I don't think we neccessarily need to specify each algorithm here and the motivation is not something we need in normative text.

[1] https://github.com/w3c/webextensions/pull/598