### PR TITLE
Proposal: `runtime.onInvalidated` event

### DIFF
--- a/proposals/runtime_on_invalidated.md
+++ b/proposals/runtime_on_invalidated.md
@@ -11,8 +11,8 @@ out.  Remove this section once the template is filled out.
 
 `browser.runtime.onInvalidated`
 
-This event allows extension frames and content scripts to be notified when
-context get invalidated.
+This event allows extension contexts which stay alive to be notified when the
+extension context get invalidated.
 
 **Document Metadata**
 
@@ -30,15 +30,16 @@ context get invalidated.
 
 ### Objective
 
-This event allows extension frames and content scripts to be notified when
-context get invalidated.
+This event allows extension contexts which stay alive to be notified when the
+extension context get invalidated.
 
 #### Use Cases
 
-When the extension context gets invalidated, this means the content script
-or frame can no longer use the chrome APIs or communicate with the extension.
+When the extension context gets invalidated, this means extension contexts
+which stay alive can no longer use the chrome APIs or communicate with other
+extension contexts.
 
-As content script or frame, knowing when this happens is crucial for moving
+For extension contexts, knowing when this happens is crucial for moving
 forward. Alternatives can be used in this situation, like `window.open` instead
 of `browser.tabs.create`. If moving forward is no option, this event can be
 used for initiating the cleanup of any side effects caused in the frames

--- a/proposals/runtime_on_invalidated.md
+++ b/proposals/runtime_on_invalidated.md
@@ -94,7 +94,7 @@ OnInvalidatedReason:
 
 ### Behavior
 
-The event would be fired when the extension context get invalidated.
+The event will be fired when the extension context get invalidated.
 The event comes with a reason which specifies why an extension got invalidated.
 
 ### New Permissions

--- a/proposals/runtime_on_invalidated.md
+++ b/proposals/runtime_on_invalidated.md
@@ -1,0 +1,157 @@
+# Proposal: browser.runtime.onInvalidated event>
+
+** How to Use This Template **
+
+See [Proposal Process](proposal_process.md) for the detailed process on how to
+propose new APIs and use this template.  Each section includes instructions on
+what to include.  Delete the instructions for a given section once it's filled
+out.  Remove this section once the template is filled out.
+
+**Summary**
+
+`browser.runtime.onInvalidated`
+
+This event allows extension frames and content scripts to be notified when
+context get invalidated.
+
+**Document Metadata**
+
+**Author:** carlosjeurissen
+
+**Sponsoring Browser:** Chrome
+
+**Contributors:** TBD
+
+**Created:** 2025-03-26
+
+**Related Issues:** https://github.com/w3c/webextensions/issues/138
+
+## Motivation
+
+### Objective
+
+This event allows extension frames and content scripts to be notified when
+context get invalidated.
+
+#### Use Cases
+
+When the extension context gets invalidated, this means the content script
+or frame can no longer use the chrome APIs or communicate with the extension.
+
+As content script or frame, knowing when this happens is crucial for moving
+forward. Alternatives can be used in this situation, like `window.open` instead
+of `browser.tabs.create`. If moving forward is no option, this event can be
+used for initiating the cleanup of any side effects caused in the frames
+extensions have been operating in.
+
+### Known Consumers
+
+Any extension with a content script which applies certain side effects to the
+web page.
+
+## Specification
+
+### Schema
+
+New onInvalidated event:
+```json
+{
+  "name": "onInvalidated",
+  "type": "function",
+  "description": "Fired when the extension context get invalidated.",
+  "parameters": [
+    {
+      "type": "object",
+      "name": "details",
+      "properties": {
+        "reason": {
+          "$ref": "OnInvalidatedReason",
+          "description": "The reason that this event is being dispatched."
+        }
+      }
+    }
+  ]
+}
+```
+
+Optionally gives a reason of type OnInvalidatedReason
+
+OnInvalidatedReason:
+
+```json
+{
+  "id": "OnInvalidatedReason",
+  "type": "string",
+  "enum": [
+    {"name": "uninstalled", "description": "Specifies the event reason as an uninstallation."},
+    {"name": "update", "description": "Specifies the event reason as an extension update."},
+    {"name": "reload", "description": "Specifies the event reason as an extension reloading."},
+    {"name": "disabled", "description": "Specifies the event reason as an extension disabling."}
+  ],
+  "description": "The reason that this event is being dispatched."
+}
+```
+
+### Behavior
+
+The event would be fired when the extension context get invalidated.
+The event comes with a reason which specifies why an extension got invalidated.
+
+### New Permissions
+
+No new permissions introduced.
+
+### Manifest File Changes
+
+No new manifest fields.
+
+## Security and Privacy
+
+### Exposed Sensitive Data
+
+Document any sensitive data or personally-identifiable information the API
+exposes to the extension.
+
+### Abuse Mitigations
+
+Currently extensions could try checking if an API gets thrown with an
+invalidated error. This would allow an extension to figure out if the extension
+is invalidated. No new abuse surface is introduced.
+
+As for the returned reason. The uninstalled reason can not be abused more than
+currently `browser.runtime.setUninstalledURL`.
+
+As for the `update` reason, this can be figured out by attempting to negotiate
+between the old content script and the new content script.
+
+The `disabled` reason could provide additional information. However this seems
+to not be a big abuse surface.
+
+### Additional Security Considerations
+
+Extensions could potentially leak the onInvalidatedReason if they try hard.
+This does not seem to introduce any attack surfaces.
+
+## Alternatives
+
+### Existing Workarounds
+
+An extension could attempt to run an API which throws when an extension is
+invalidated. This is very expensive as it would require to run this API in a
+loop. In addition, the lack of an onInvalidated event leads to many
+extension developers to not deal with the situation in which the context is
+invalidated. Introducing the onInvalidated encourages developers to handle
+these situations.
+
+### Open Web API
+
+There is no viable path to turn this into an Open Web API.
+
+## Implementation Notes
+
+The event should be fired in the situation in which extension APIs would throw
+with an context invalidated error.
+
+## Future Work
+
+Not at this moment

--- a/proposals/runtime_on_invalidated.md
+++ b/proposals/runtime_on_invalidated.md
@@ -1,12 +1,5 @@
 # Proposal: browser.runtime.onInvalidated event
 
-** How to Use This Template **
-
-See [Proposal Process](proposal_process.md) for the detailed process on how to
-propose new APIs and use this template.  Each section includes instructions on
-what to include.  Delete the instructions for a given section once it's filled
-out.  Remove this section once the template is filled out.
-
 **Summary**
 
 `browser.runtime.onInvalidated`

--- a/proposals/runtime_on_invalidated.md
+++ b/proposals/runtime_on_invalidated.md
@@ -28,7 +28,7 @@ extension context get invalidated.
 #### Use Cases
 
 When the extension context gets invalidated, this means extension contexts
-which stay alive can no longer use the chrome APIs or communicate with other
+which stay alive can no longer use the extension APIs or communicate with other
 extension contexts.
 
 For extension contexts, knowing when this happens is crucial for moving

--- a/proposals/runtime_on_invalidated.md
+++ b/proposals/runtime_on_invalidated.md
@@ -50,7 +50,7 @@ New onInvalidated event:
 {
   "name": "onInvalidated",
   "type": "function",
-  "description": "Fired when the extension context get invalidated.",
+  "description": "Fired when the extension context get invalidated while the underlying document remains valid.",
   "parameters": [
     {
       "type": "object",

--- a/proposals/runtime_on_invalidated.md
+++ b/proposals/runtime_on_invalidated.md
@@ -13,7 +13,7 @@ context gets invalidated.
 
 **Sponsoring Browser:** Chrome
 
-**Contributors:** bershanskiy
+**Contributors:** bershanskiy, xeenon, robwu
 
 **Created:** 2025-03-26
 

--- a/proposals/runtime_on_invalidated.md
+++ b/proposals/runtime_on_invalidated.md
@@ -4,8 +4,7 @@
 
 `browser.runtime.onInvalidated`
 
-This event allows extension contexts which stay alive to be notified when the
-extension context get invalidated.
+This event notifies extension contexts that remain alive when the extension context gets invalidated.
 
 **Document Metadata**
 

--- a/proposals/runtime_on_invalidated.md
+++ b/proposals/runtime_on_invalidated.md
@@ -22,8 +22,7 @@ This event notifies extension contexts that remain alive when the extension cont
 
 ### Objective
 
-This event allows extension contexts which stay alive to be notified when the
-extension context get invalidated.
+This event notifies extension contexts that remain alive when the extension context gets invalidated.
 
 #### Use Cases
 

--- a/proposals/runtime_on_invalidated.md
+++ b/proposals/runtime_on_invalidated.md
@@ -83,10 +83,10 @@ OnInvalidatedReason:
   "id": "OnInvalidatedReason",
   "type": "string",
   "enum": [
-    {"name": "uninstalled", "description": "Specifies the event reason as an uninstallation."},
+    {"name": "uninstall", "description": "Specifies the event reason as an uninstallation."},
     {"name": "update", "description": "Specifies the event reason as an extension update."},
     {"name": "reload", "description": "Specifies the event reason as an extension reloading."},
-    {"name": "disabled", "description": "Specifies the event reason as an extension disabling."}
+    {"name": "disable", "description": "Specifies the event reason as an extension disabling."}
   ],
   "description": "The reason that this event is being dispatched."
 }
@@ -118,13 +118,13 @@ Currently extensions could try checking if an API gets thrown with an
 invalidated error. This would allow an extension to figure out if the extension
 is invalidated. No new abuse surface is introduced.
 
-As for the returned reason. The uninstalled reason can not be abused more than
+As for the returned reason. The `uninstall` reason can not be abused more than
 currently `browser.runtime.setUninstalledURL`.
 
 As for the `update` reason, this can be figured out by attempting to negotiate
 between the old content script and the new content script.
 
-The `disabled` reason could provide additional information. However this seems
+The `disable` reason could provide additional information. However this seems
 to not be a big abuse surface.
 
 ### Additional Security Considerations

--- a/proposals/runtime_on_invalidated.md
+++ b/proposals/runtime_on_invalidated.md
@@ -4,7 +4,8 @@
 
 `browser.runtime.onInvalidated`
 
-This event notifies extension contexts that remain alive when the extension context gets invalidated.
+This event notifies extension contexts that remain alive when the extension
+context gets invalidated.
 
 **Document Metadata**
 
@@ -22,7 +23,8 @@ This event notifies extension contexts that remain alive when the extension cont
 
 ### Objective
 
-This event notifies extension contexts that remain alive when the extension context gets invalidated.
+This event notifies extension contexts that remain alive when the extension
+context gets invalidated.
 
 #### Use Cases
 
@@ -86,7 +88,10 @@ OnInvalidatedReason:
 
 ### Behavior
 
-The event will be fired when the extension context get invalidated.
+The event will be fired when the extension context get invalidated while the
+underlying document remains valid. The event only fires in extension contexts
+which are not already killed on invalidation.
+
 The event comes with a reason which specifies why an extension got invalidated.
 
 ### New Permissions
@@ -101,8 +106,8 @@ No new manifest fields.
 
 ### Exposed Sensitive Data
 
-Document any sensitive data or personally-identifiable information the API
-exposes to the extension.
+The event gives an invalidation reason. This could be used for gathering figures
+on extension updates and uninstalls.
 
 ### Abuse Mitigations
 
@@ -110,8 +115,10 @@ Currently extensions could try checking if an API gets thrown with an
 invalidated error. This would allow an extension to figure out if the extension
 is invalidated. No new abuse surface is introduced.
 
-As for the returned reason. The `uninstall` reason can not be abused more than
-currently `browser.runtime.setUninstalledURL`.
+As for the returned reason. The `uninstall` reason could potentially be used
+by extensions to modify every page to nag the user about reinstalling the
+extension. However extensions currently can already ask for this once by setting
+`browser.runtime.setUninstalledURL`.
 
 As for the `update` reason, this can be figured out by attempting to negotiate
 between the old content script and the new content script.

--- a/proposals/runtime_on_invalidated.md
+++ b/proposals/runtime_on_invalidated.md
@@ -74,7 +74,7 @@ New onInvalidated event:
 }
 ```
 
-Optionally gives a reason of type OnInvalidatedReason
+The event should have a reason of type OnInvalidatedReason
 
 OnInvalidatedReason:
 

--- a/proposals/runtime_on_invalidated.md
+++ b/proposals/runtime_on_invalidated.md
@@ -1,4 +1,4 @@
-# Proposal: browser.runtime.onInvalidated event>
+# Proposal: browser.runtime.onInvalidated event
 
 ** How to Use This Template **
 
@@ -20,7 +20,7 @@ extension context get invalidated.
 
 **Sponsoring Browser:** Chrome
 
-**Contributors:** TBD
+**Contributors:** bershanskiy
 
 **Created:** 2025-03-26
 


### PR DESCRIPTION
Proposal for https://github.com/w3c/webextensions/issues/138 and https://github.com/w3c/webextensions/issues/789

It introduces a new event which fires in contentScripts and extension frames when the background scripts get invalidated. In the event is a reason property stating the reason for the invalidation.

@bershanskiy @fregante love to hear your feedback.
