### PR TITLE
Proposal: API to Query Side Panel Layout

### DIFF
--- a/proposals/getposition-sidepanel.md
+++ b/proposals/getposition-sidepanel.md
@@ -1,4 +1,4 @@
-# Add API to Query Side Panel Position
+# Add API to Query Side Panel Layout
 
 **Summary**
 
@@ -47,14 +47,14 @@ namespace sidePanel {
     enum Side {
         LEFT = "left",
         RIGHT = "right"
-    }
+    };
 
-    interface PanelPosition {
+    interface PanelLayout {
         side: Side;
-    }
+    };
 
     // Example function declarations
-    function getPosition(): Promise<PanelPosition>;
+    function getLayout(): Promise<PanelPosition>;
 }
 ```
 
@@ -112,8 +112,8 @@ N/A
 ## Basic uses
 
 ```typescript
-chrome.sidePanel.getPosition().then(position => {
-  console.log(`Panel is on the ${position} side`);
-  applyPositionSpecificStyles(position);
+chrome.sidePanel.getLayout().then(layout => {
+  console.log(`Panel is on the ${layout.side} side`);
+  applyPositionSpecificStyles(layout.side);
 });
 ```

--- a/proposals/getposition-sidepanel.md
+++ b/proposals/getposition-sidepanel.md
@@ -1,0 +1,120 @@
+# Add API to Query Side Panel Position
+
+**Summary**
+Proposal to introduce a programmatic way to query the Side panel position.
+
+**Document Metadata**
+
+**Author:** [hharshas](https://github.com/hharshas)
+
+**Sponsoring Browser:** Chromium
+
+**Contributors:** [hharshas](https://github.com/hharshas) ([Summer Of Code](https://summerofcode.withgoogle.com/)), mentor: oliverdunk, solomonkinard
+
+**Created:** 2025-05-27
+
+**Related Issues:** [#chromium](https://issues.chromium.org/issues/406511291)
+
+## Motivation
+
+### Objective
+
+- At chrome://settings, it is possible to change the "Side panel position" which affects which side of the browser the side panel UI opens on. This can include panels registered by the developer using the sidePanel API.
+- We should add a way to query this so the developer can adjust their UI based on the position.
+
+#### Use Cases
+
+Programmatic Control: 
+- For example having phrasing or visuals that depend on the relative position of the page.
+
+### Known Consumers
+
+The Chromium bug has some amount of developer interest. This item is under consideration by Chrome among work items for Summer of Code.
+
+## Specification
+
+### Schema
+
+```typescript
+namespace sidePanel {
+ namespace sidePanel {
+  // Possible side panel positions
+  enum PanelPosition {
+    LEFT = "left",
+    RIGHT = "right"
+  };
+
+  interface Functions {
+    // Returns the current position of the side panel
+    // Returns: Promise that resolves with the current position
+    static Promise<PanelPosition> getPosition();
+    
+    ////
+    // Alternative approach for future extensibility (open for discussion)
+    dictionary PanelSettings {
+      PanelPosition position;
+      // Future settings could be added here
+    };
+    
+    static Promise<PanelSettings> getSettings();
+  };
+};
+```
+
+### Return value
+
+- Type: Promise<void>
+
+- Resolves when it returns the panel position.
+
+### Behavior
+    - Returns the current position as set in browser settings. 
+    - No context option is needed as the setting is same for all the context.
+
+### New Permissions
+N/A.
+
+### Manifest File Changes
+N/A
+
+## Security and Privacy
+
+### Exposed Sensitive Data
+
+This API does not expose any sensitive data.
+
+### Abuse Mitigations
+
+The API is fetching only the side panel position.
+
+### Additional Security Considerations
+
+N/A
+
+## Alternatives
+
+### Existing Workarounds
+
+  - So far, nothing works. The DOM of the side panel and the content script are separate, so even if we detect the resize event when the side panel is opened, we can't determine the panel's position. It will be interesting to see others' approaches in the comments of this PR.
+
+### Open Web API
+
+This API is intended to support panels registered by the developer using the Side Panel API, so it does not belong on the open web.
+
+## Implementation Notes
+
+N/A.
+
+## Future Work
+
+- Additional Settings: Expand getSettings() with more panel configuration options
+- Position Change Events: Add event listener for position changes (again open for discussion)
+
+## Basic uses
+
+```typescript
+chrome.sidePanel.getPosition().then(position => {
+  console.log(`Panel is on the ${position} side`);
+  applyPositionSpecificStyles(position);
+});
+```

--- a/proposals/getposition-sidepanel.md
+++ b/proposals/getposition-sidepanel.md
@@ -53,14 +53,8 @@ namespace sidePanel {
         side: Side;
     }
 
-    interface PanelSettings {
-        position: PanelPosition;
-        // Future settings could be added here
-    }
-
     // Example function declarations
     function getPosition(): Promise<PanelPosition>;
-    function getSettings(): Promise<PanelSettings>;
 }
 ```
 
@@ -113,7 +107,7 @@ N/A
 
 ## Future Work
 
-* Additional Settings: Expand `getSettings()` with more panel configuration options.
+N/A
 
 ## Basic uses
 

--- a/proposals/getposition-sidepanel.md
+++ b/proposals/getposition-sidepanel.md
@@ -23,7 +23,7 @@ Proposal to introduce a programmatic way to query the Side panel position.
 
 * Browsers may offer users the ability to change which side of the browser
   the side panel opens on. In Chrome, this is exposed at `chrome://settings`.
-  This can include side panels registered by the extensions using the sidePanel API.
+  This can include side panels registered by the extensions using the `sidePanel` API.
 * We should add a way to query this so the developer can adjust their UI
   based on the position.
 

--- a/proposals/getposition-sidepanel.md
+++ b/proposals/getposition-sidepanel.md
@@ -21,9 +21,9 @@ Proposal to introduce a programmatic way to query the Side panel position.
 
 ### Objective
 
-* At `chrome://settings`, it is possible to change the "Side panel position"
-  which affects which side of the browser the side panel UI opens on. This
-  can include panels registered by the developer using the sidePanel API.
+* Browsers may offer users the ability to change which side of the browser
+  the side panel opens on. In Chrome, this is exposed at `chrome://settings`.
+  This can include side panels registered by the extensions using the sidePanel API.
 * We should add a way to query this so the developer can adjust their UI
   based on the position.
 
@@ -43,26 +43,25 @@ consideration by Chrome among work items for Summer of Code.
 
 ```typescript
 namespace sidePanel {
- namespace sidePanel {
-  // Possible side panel positions
-  enum PanelPosition {
-    LEFT = "left",
-    RIGHT = "right"
-  };
+    // Possible side panel positions
+    enum Side {
+        LEFT = "left",
+        RIGHT = "right"
+    }
 
-  interface Functions {
-    // Returns the current position of the side panel.
-    static Promise<PanelPosition> getPosition();
-    
-    // Alternative approach for future extensibility (open for discussion).
-    dictionary PanelSettings {
-      PanelPosition position;
-      // Future settings could be added here.
-    };
-    
-    static Promise<PanelSettings> getSettings();
-  };
-};
+    interface PanelPosition {
+        side: Side;
+    }
+
+    interface PanelSettings {
+        position: PanelPosition;
+        // Future settings could be added here
+    }
+
+    // Example function declarations
+    function getPosition(): Promise<PanelPosition>;
+    function getSettings(): Promise<PanelSettings>;
+}
 ```
 
 ### Return value
@@ -101,11 +100,7 @@ N/A
 
 ### Existing Workarounds
 
-So far, nothing works. The DOM of the side panel and the
-content script are separate, so even if we detect the resize
-event when the side panel is opened, we can't determine the
-panel's position. It will be interesting to see other's
-approaches in the comments of this PR.
+N/A
 
 ### Open Web API
 

--- a/proposals/getposition-sidepanel.md
+++ b/proposals/getposition-sidepanel.md
@@ -60,7 +60,7 @@ namespace sidePanel {
 
 ### Return value
 
-* Type: Promise<void>
+* Type: `Promise<PanelPosition>`
 * Resolves when it returns the panel position.
 
 ### Behavior

--- a/proposals/getposition-sidepanel.md
+++ b/proposals/getposition-sidepanel.md
@@ -9,7 +9,8 @@ Proposal to introduce a programmatic way to query the Side panel position.
 
 **Sponsoring Browser:** Chromium
 
-**Contributors:** [hharshas](https://github.com/hharshas) ([Summer Of Code](https://summerofcode.withgoogle.com/)), mentor: oliverdunk, solomonkinard
+**Contributors:** [hharshas](https://github.com/hharshas) 
+([Summer Of Code](https://summerofcode.withgoogle.com/)), mentor: oliverdunk, solomonkinard
 
 **Created:** 2025-05-27
 
@@ -19,8 +20,11 @@ Proposal to introduce a programmatic way to query the Side panel position.
 
 ### Objective
 
-- At chrome://settings, it is possible to change the "Side panel position" which affects which side of the browser the side panel UI opens on. This can include panels registered by the developer using the sidePanel API.
-- We should add a way to query this so the developer can adjust their UI based on the position.
+* At chrome://settings, it is possible to change the "Side panel position"
+ which affects which side of the browser the side panel UI opens on.
+  This can include panels registered by the developer using the sidePanel API.
+* We should add a way to query this so the developer can adjust their UI 
+based on the position.
 
 #### Use Cases
 
@@ -29,7 +33,8 @@ Programmatic Control:
 
 ### Known Consumers
 
-The Chromium bug has some amount of developer interest. This item is under consideration by Chrome among work items for Summer of Code.
+The Chromium bug has some amount of developer interest. This item is under 
+consideration by Chrome among work items for Summer of Code.
 
 ## Specification
 
@@ -49,7 +54,6 @@ namespace sidePanel {
     // Returns: Promise that resolves with the current position
     static Promise<PanelPosition> getPosition();
     
-    ////
     // Alternative approach for future extensibility (open for discussion)
     dictionary PanelSettings {
       PanelPosition position;
@@ -68,8 +72,8 @@ namespace sidePanel {
 - Resolves when it returns the panel position.
 
 ### Behavior
-    - Returns the current position as set in browser settings. 
-    - No context option is needed as the setting is same for all the context.
+- Returns the current position as set in browser settings. 
+- No context option is needed as the setting is same for all the context.
 
 ### New Permissions
 N/A.
@@ -95,11 +99,16 @@ N/A
 
 ### Existing Workarounds
 
-  - So far, nothing works. The DOM of the side panel and the content script are separate, so even if we detect the resize event when the side panel is opened, we can't determine the panel's position. It will be interesting to see others' approaches in the comments of this PR.
+So far, nothing works. The DOM of the side panel and the
+ content script are separate, so even if we detect the resize 
+ event when the side panel is opened, we can't determine the
+ panel's position. It will be interesting to see other's
+ approaches in the comments of this PR.
 
 ### Open Web API
 
-This API is intended to support panels registered by the developer using the Side Panel API, so it does not belong on the open web.
+This API is intended to support panels registered by
+ the developer using the Side Panel API, so it does not belong on the open web.
 
 ## Implementation Notes
 
@@ -107,8 +116,9 @@ N/A.
 
 ## Future Work
 
-- Additional Settings: Expand getSettings() with more panel configuration options
-- Position Change Events: Add event listener for position changes (again open for discussion)
+* Additional Settings: Expand getSettings() with more panel configuration options.
+* Position Change Events: Add event listener for
+ position changes (again open for discussion).
 
 ## Basic uses
 

--- a/proposals/getposition-sidepanel.md
+++ b/proposals/getposition-sidepanel.md
@@ -1,6 +1,7 @@
 # Add API to Query Side Panel Position
 
 **Summary**
+
 Proposal to introduce a programmatic way to query the Side panel position.
 
 **Document Metadata**
@@ -9,7 +10,7 @@ Proposal to introduce a programmatic way to query the Side panel position.
 
 **Sponsoring Browser:** Chromium
 
-**Contributors:** [hharshas](https://github.com/hharshas) 
+**Contributors:** [hharshas](https://github.com/hharshas)
 ([Summer Of Code](https://summerofcode.withgoogle.com/)), mentor: oliverdunk, solomonkinard
 
 **Created:** 2025-05-27
@@ -20,20 +21,20 @@ Proposal to introduce a programmatic way to query the Side panel position.
 
 ### Objective
 
-* At chrome://settings, it is possible to change the "Side panel position"
- which affects which side of the browser the side panel UI opens on.
-  This can include panels registered by the developer using the sidePanel API.
-* We should add a way to query this so the developer can adjust their UI 
-based on the position.
+* At `chrome://settings`, it is possible to change the "Side panel position"
+  which affects which side of the browser the side panel UI opens on. This
+  can include panels registered by the developer using the sidePanel API.
+* We should add a way to query this so the developer can adjust their UI
+  based on the position.
 
 #### Use Cases
 
 Programmatic Control: 
-- For example having phrasing or visuals that depend on the relative position of the page.
+* For example, having phrasing or visuals that depend on the relative position of the page.
 
 ### Known Consumers
 
-The Chromium bug has some amount of developer interest. This item is under 
+The Chromium bug has some amount of developer interest. This item is under
 consideration by Chrome among work items for Summer of Code.
 
 ## Specification
@@ -50,14 +51,13 @@ namespace sidePanel {
   };
 
   interface Functions {
-    // Returns the current position of the side panel
-    // Returns: Promise that resolves with the current position
+    // Returns the current position of the side panel.
     static Promise<PanelPosition> getPosition();
     
-    // Alternative approach for future extensibility (open for discussion)
+    // Alternative approach for future extensibility (open for discussion).
     dictionary PanelSettings {
       PanelPosition position;
-      // Future settings could be added here
+      // Future settings could be added here.
     };
     
     static Promise<PanelSettings> getSettings();
@@ -67,18 +67,20 @@ namespace sidePanel {
 
 ### Return value
 
-- Type: Promise<void>
-
-- Resolves when it returns the panel position.
+* Type: Promise<void>
+* Resolves when it returns the panel position.
 
 ### Behavior
-- Returns the current position as set in browser settings. 
-- No context option is needed as the setting is same for all the context.
+
+* Returns the current position as set in browser settings.
+* No context option is needed as the setting is same for all the context.
 
 ### New Permissions
-N/A.
+
+N/A
 
 ### Manifest File Changes
+
 N/A
 
 ## Security and Privacy
@@ -100,23 +102,23 @@ N/A
 ### Existing Workarounds
 
 So far, nothing works. The DOM of the side panel and the
- content script are separate, so even if we detect the resize 
- event when the side panel is opened, we can't determine the
- panel's position. It will be interesting to see other's
- approaches in the comments of this PR.
+content script are separate, so even if we detect the resize
+event when the side panel is opened, we can't determine the
+panel's position. It will be interesting to see other's
+approaches in the comments of this PR.
 
 ### Open Web API
 
 This API is intended to support panels registered by
- the developer using the Side Panel API, so it does not belong on the open web.
+the developer using the Side Panel API, so it does not belong on the open web.
 
 ## Implementation Notes
 
-N/A.
+N/A
 
 ## Future Work
 
-* Additional Settings: Expand getSettings() with more panel configuration options.
+* Additional Settings: Expand `getSettings()` with more panel configuration options.
 
 ## Basic uses
 

--- a/proposals/getposition-sidepanel.md
+++ b/proposals/getposition-sidepanel.md
@@ -117,8 +117,6 @@ N/A.
 ## Future Work
 
 * Additional Settings: Expand getSettings() with more panel configuration options.
-* Position Change Events: Add event listener for
- position changes (again open for discussion).
 
 ## Basic uses
 

--- a/proposals/getposition-sidepanel.md
+++ b/proposals/getposition-sidepanel.md
@@ -15,7 +15,7 @@ Proposal to introduce a programmatic way to query the Side panel position.
 
 **Created:** 2025-05-27
 
-**Related Issues:** [#chromium](https://issues.chromium.org/issues/406511291)
+**Related Issues:** https://issues.chromium.org/issues/406511291
 
 ## Motivation
 

--- a/proposals/sidepanel-getlayout.md
+++ b/proposals/sidepanel-getlayout.md
@@ -43,7 +43,7 @@ consideration by Chrome among work items for Summer of Code.
 
 ```typescript
 namespace sidePanel {
-    // Possible side panel positions
+    // Possible side panel positions.
     enum Side {
         LEFT = "left",
         RIGHT = "right"
@@ -54,13 +54,13 @@ namespace sidePanel {
     };
 
     // Example function declarations
-    function getLayout(): Promise<PanelPosition>;
+    function getLayout(): Promise<PanelLayout>;
 }
 ```
 
 ### Return value
 
-* Type: `Promise<PanelPosition>`
+* Type: `Promise<PanelLayout>`
 * Resolves when it returns the panel position.
 
 ### Behavior


### PR DESCRIPTION
This proposal adds a method to detect the side panel's current alignment (left/right) as set in chrome://settings/appearance.  Feedback is appreciated! #833 [#chromium](https://issues.chromium.org/issues/406511291)  [Summer of Code](https://summerofcode.withgoogle.com/)