### PR TITLE
Add specification for `externally_connectable`.

### DIFF
--- a/specification/index.bs
+++ b/specification/index.bs
@@ -8,6 +8,7 @@ URL: https://w3c.github.io/webextensions/specification/index.html
 Editor: Mukul Purohit, Microsoft Corporation https://www.microsoft.com, mpurohit@microsoft.com
 Editor: Tomislav Jovanovic, Mozilla https://www.mozilla.org/, tjovanovic@mozilla.com
 Editor: Oliver Dunk, Google https://www.google.com, oliverdunk@chromium.org
+Editor: Kiara Rose, Apple https://www.apple.com, kiara_rose@apple.com
 Abstract: [Placeholder] Abstract.
 Markup Shorthands: markdown yes
 </pre>
@@ -143,7 +144,19 @@ This key may be present.
 
 ### Key `externally_connectable`
 
-This key may be present.
+The <a href="#key-externally_connectable">`externally_connectable`</a> key declares which extensions and web pages can establish connections to the extension using [=runtime.connect()=] and [=runtime.sendMessage()=]. If omitted, all extensions may connect, but no web pages can connect.
+
+This key may be present and may include the following optional keys:
+
+#### Key `ids`
+
+A [=list=] of [=extension IDs=] that specifies which extensions can communicate with the extension. To allow all extensions, include the pattern `*` in the list. If left empty or omitted, no extensions can connect.
+
+#### Key `matches`
+
+A [=list=] of [=match patterns=] that specifies which web pages can communicate with the extension. If left empty or omitted, no web pages can connect.
+
+Any [=match patterns=] that include wildcard domains, or wildcard subdomains of a top-level domain, must be ignored.
 
 ### Key `devtools_page`
 

--- a/specification/index.bs
+++ b/specification/index.bs
@@ -146,11 +146,13 @@ This key may be present.
 
 The <a href="#key-externally_connectable">`externally_connectable`</a> key declares which extensions and web pages can establish connections to the extension using [=runtime.connect()=] and [=runtime.sendMessage()=]. If omitted, all extensions may connect, but no web pages can connect.
 
+A connection from an external web page or extension triggers the [=runtime.onConnectExternal=] event listener to fire. Similarly, a message sent by an external web page or extension triggers the [=runtime.onMessageExternal=] event listener to fire.
+
 This key may be present and may include the following optional keys:
 
 #### Key `ids`
 
-A [=list=] of [=extension IDs=] that specifies which extensions can communicate with the extension. To allow all extensions, include the pattern `*` in the list. If left empty or omitted, no extensions can connect.
+A [=list=] of [=extension IDs=] that specifies which extensions can communicate with the extension. To allow all extensions to connect, include the wildcard pattern `*`. If left empty or omitted while the `externally_connectable` key is present, no extensions can connect.
 
 #### Key `matches`
 

--- a/specification/index.bs
+++ b/specification/index.bs
@@ -152,7 +152,7 @@ The <a href="#key-externally_connectable">`externally_connectable`</a> key decla
 
 A connection from an external web page or extension triggers the [=runtime.onConnectExternal=] event listener to fire. Similarly, a message sent by an external web page or extension triggers the [=runtime.onMessageExternal=] event listener to fire.
 
-These events are not available to web pages, only in privileged extension contexts.
+These events are not available to web pages, only in a [=privileged extension context=].
 
 This key may be present and may include the following optional keys:
 

--- a/specification/index.bs
+++ b/specification/index.bs
@@ -152,6 +152,8 @@ The <a href="#key-externally_connectable">`externally_connectable`</a> key decla
 
 A connection from an external web page or extension triggers the [=runtime.onConnectExternal=] event listener to fire. Similarly, a message sent by an external web page or extension triggers the [=runtime.onMessageExternal=] event listener to fire.
 
+These events are not available to web pages, only in privileged extension contexts.
+
 This key may be present and may include the following optional keys:
 
 #### Key `ids`
@@ -162,7 +164,7 @@ A [=list=] of [=extension IDs=] that specifies which extensions can communicate 
 
 A [=list=] of [=match patterns=] that specifies which web pages can communicate with the extension. If left empty or omitted, no web pages can connect.
 
-Any [=match patterns=] that include wildcard domains, or wildcard subdomains of a top-level domain, must be ignored.
+Note: Only the document's own URL is used for matching. There is no fallback to the URL of the document that created it.
 
 ### Key `devtools_page`
 

--- a/specification/index.bs
+++ b/specification/index.bs
@@ -8,6 +8,7 @@ URL: https://w3c.github.io/webextensions/specification/
 Editor: Mukul Purohit, Microsoft Corporation https://www.microsoft.com, mpurohit@microsoft.com
 Editor: Tomislav Jovanovic, Mozilla https://www.mozilla.org/, tjovanovic@mozilla.com
 Editor: Oliver Dunk, Google https://www.google.com, oliverdunk@chromium.org
+Editor: Kiara Rose, Apple https://www.apple.com, kiara_rose@apple.com
 Abstract: [Placeholder] Abstract.
 Repository: w3c/webextensions
 Markup Shorthands: markdown yes
@@ -147,7 +148,19 @@ This key may be present.
 
 ### Key `externally_connectable`
 
-This key may be present.
+The <a href="#key-externally_connectable">`externally_connectable`</a> key declares which extensions and web pages can establish connections to the extension using [=runtime.connect()=] and [=runtime.sendMessage()=]. If omitted, all extensions may connect, but no web pages can connect.
+
+This key may be present and may include the following optional keys:
+
+#### Key `ids`
+
+A [=list=] of [=extension IDs=] that specifies which extensions can communicate with the extension. To allow all extensions, include the pattern `*` in the list. If left empty or omitted, no extensions can connect.
+
+#### Key `matches`
+
+A [=list=] of [=match patterns=] that specifies which web pages can communicate with the extension. If left empty or omitted, no web pages can connect.
+
+Any [=match patterns=] that include wildcard domains, or wildcard subdomains of a top-level domain, must be ignored.
 
 ### Key `devtools_page`
 

--- a/specification/index.bs
+++ b/specification/index.bs
@@ -150,11 +150,13 @@ This key may be present.
 
 The <a href="#key-externally_connectable">`externally_connectable`</a> key declares which extensions and web pages can establish connections to the extension using [=runtime.connect()=] and [=runtime.sendMessage()=]. If omitted, all extensions may connect, but no web pages can connect.
 
+A connection from an external web page or extension triggers the [=runtime.onConnectExternal=] event listener to fire. Similarly, a message sent by an external web page or extension triggers the [=runtime.onMessageExternal=] event listener to fire.
+
 This key may be present and may include the following optional keys:
 
 #### Key `ids`
 
-A [=list=] of [=extension IDs=] that specifies which extensions can communicate with the extension. To allow all extensions, include the pattern `*` in the list. If left empty or omitted, no extensions can connect.
+A [=list=] of [=extension IDs=] that specifies which extensions can communicate with the extension. To allow all extensions to connect, include the wildcard pattern `*`. If left empty or omitted while the `externally_connectable` key is present, no extensions can connect.
 
 #### Key `matches`
 

--- a/specification/index.bs
+++ b/specification/index.bs
@@ -150,15 +150,15 @@ This key may be present.
 
 The <a href="#key-externally_connectable">`externally_connectable`</a> key declares which extensions and web pages can establish connections to the extension using [=runtime.connect()=] and [=runtime.sendMessage()=]. If omitted, all extensions may connect, but no web pages can connect.
 
-A connection from an external web page or extension triggers the [=runtime.onConnectExternal=] event listener to fire. Similarly, a message sent by an external web page or extension triggers the [=runtime.onMessageExternal=] event listener to fire.
-
-These events are not available to web pages, only in a [=privileged extension context=].
+A call to [=runtime.connect()=] from an external web page or extension triggers the [=runtime.onConnectExternal=] event listener to fire. Similarly, a message sent by an external web page or extension with [=runtime.sendMessage()=] triggers the [=runtime.onMessageExternal=] event listener to fire. These events are only available in a [=privileged extension context=], not in web pages or less-privileged contexts like [=content scripts=].
 
 This key may be present and may include the following optional keys:
 
 #### Key `ids` #### {#key-externally_connectable-ids}
 
-A [=list=] of [=extension IDs=] that specifies which extensions can communicate with the extension. To allow all extensions to connect, include the wildcard pattern `*`. If left empty or omitted while the `externally_connectable` key is present, no extensions can connect.
+A [=list=] of [=extension IDs=] that specifies which extensions can communicate with the extension. To allow all extensions to connect, include the wildcard pattern `"*"`.
+
+Note: The default of whether an extension can connect changes based on whether the `externally_connectable` key is present. If the key is omitted, the default is to allow all extensions to connect. If the key is present, no extensions can connect unless specified in `"ids"`, even if the `"ids"` key is ommitted.
 
 #### Key `matches` #### {#key-externally_connectable-matches}
 

--- a/specification/index.bs
+++ b/specification/index.bs
@@ -156,11 +156,11 @@ These events are not available to web pages, only in a [=privileged extension co
 
 This key may be present and may include the following optional keys:
 
-#### Key `ids`
+#### Key `ids` #### {#key-externally_connectable-ids}
 
 A [=list=] of [=extension IDs=] that specifies which extensions can communicate with the extension. To allow all extensions to connect, include the wildcard pattern `*`. If left empty or omitted while the `externally_connectable` key is present, no extensions can connect.
 
-#### Key `matches`
+#### Key `matches` #### {#key-externally_connectable-matches}
 
 A [=list=] of [=match patterns=] that specifies which web pages can communicate with the extension. If left empty or omitted, no web pages can connect.
 
@@ -275,13 +275,13 @@ A <dfn>glob</dfn> can be any [=string=]. It can contain any number of wildcards 
 
 Content scripts represent a set of JS and CSS files that should be injected into matching pages loaded by the user agent. They are injected using the steps in [[#inject-a-content-script]]. Content scripts run in an [=isolated world=] by default.
 
-### Key `matches`
+### Key `matches` ### {#key-content_scripts-matches}
 
 A [=list=] of [=match patterns=] that are used to decide which pages the user agent injects the content script into. This key is required.
 
 ### Key `exclude_matches`
 
-A [=list=] of [=match patterns=] that can be used to specify URLs where the content script should not run, even if the URL matches entries in [[#key-matches]] and (if specified) [[#key-include_globs]].
+A [=list=] of [=match patterns=] that can be used to specify URLs where the content script should not run, even if the URL matches entries in [[#key-content_scripts-matches]] and (if specified) [[#key-include_globs]].
 
 ### Key `js`
 
@@ -303,7 +303,7 @@ If this is `true`, use the URL of the parent frame when matching a child frame w
 
 If this is `true`, use fallbacks as described in [[#determine-the-url-for-matching-a-document]].
 
-No path is available when the URL to match against falls back to an origin. Therefore, when set, the user agent may treat a [[#key-matches]] with a path other than `/*` as an error.
+No path is available when the URL to match against falls back to an origin. Therefore, when set, the user agent may treat a [[#key-content_scripts-matches]] with a path other than `/*` as an error.
 
 Defaults to `false`.
 
@@ -313,11 +313,11 @@ Specifies when the content script should be injected. Valid values are defined b
 
 ### Key `include_globs`
 
-A list of [=globs=] that a document should match. A document matches if the URL matches both the [[#key-matches]] field and the [[#key-include_globs]] field.
+A list of [=globs=] that a document should match. A document matches if the URL matches both the [[#key-content_scripts-matches]] field and the [[#key-include_globs]] field.
 
 ### Key `exclude_globs`
 
-A [=list=] of [=globs=] that can be used to specify URLs where the content script should not run, even if the URL matches entries in [[#key-matches]] and (if specified) [[#key-include_globs]].
+A [=list=] of [=globs=] that can be used to specify URLs where the content script should not run, even if the URL matches entries in [[#key-content_scripts-matches]] and (if specified) [[#key-include_globs]].
 
 ### Key `world`
 


### PR DESCRIPTION
Here's a first draft of a spec for `externally_connectable`. I'm not sure if the way it's written is spec-y enough so open to all feedback for improvements


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kiaraarose/webextensions/pull/873.html" title="Last updated on Aug 5, 2026, 7:36 PM UTC (69844f4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webextensions/873/1fbcd29...kiaraarose:69844f4.html" title="Last updated on Aug 5, 2026, 7:36 PM UTC (69844f4)">Diff</a>