### PR TITLE
Correct `iconVariants` and `colorSchemes` casing. Add `NotificationOptions.iconVariants`

### DIFF
--- a/proposals/dark_mode_extension_icons.md
+++ b/proposals/dark_mode_extension_icons.md
@@ -115,7 +115,7 @@ menus.update(id, menusProperties);
   iconVariants: exampleProperties
 }
 
-if iconVariants is specified, iconUrl will be ignored.
+If `iconVariants` is specified, `iconUrl` will be ignored.
 
 In a past version of the proposal and in earlier implementations in Safari. `icon_variants` and `color_schemes` was used instead of `iconVariants` and `colorSchemes`.
 ```

--- a/proposals/dark_mode_extension_icons.md
+++ b/proposals/dark_mode_extension_icons.md
@@ -90,12 +90,12 @@ const exampleProperties: {string: string | ImageData}[] = [
   {
     "16": darkImageData16,
     "32": darkImageData32,
-    "color_schemes": ["dark"]
+    "colorSchemes": ["dark"]
   },
   {
     "16": lightImageData16,
     "32": lightImageData32,
-    "color_schemes": ["light"]
+    "colorSchemes": ["light"]
   }
 ];
 
@@ -104,9 +104,20 @@ const createProperties = {variants: exampleProperties};
 action.setIcon(createProperties);
 
 // menus.*(), for supporting browsers.
-const menusProperties = {icon_variants: exampleProperties};
+const menusProperties = {iconVariants: exampleProperties};
 menus.create(menusProperties);
 menus.update(id, menusProperties);
+
+// notifications.NotificationOptions
+{
+  type: "basic",
+  iconUrl: "/icon.png",
+  iconVariants: exampleProperties
+}
+
+if iconVariants is specified, iconUrl will be ignored.
+
+In a past version of the proposal and in earlier implementations in Safari. `icon_variants` and `color_schemes` was used instead of `iconVariants` and `colorSchemes`.
 ```
 
 A benefit of this new structure is that it's more resilient to future changes,

--- a/proposals/dark_mode_extension_icons.md
+++ b/proposals/dark_mode_extension_icons.md
@@ -117,7 +117,7 @@ menus.update(id, menusProperties);
 
 If `iconVariants` is specified, `iconUrl` will be ignored.
 
-In a past version of the proposal and in earlier implementations in Safari. `icon_variants` and `color_schemes` was used instead of `iconVariants` and `colorSchemes`.
+Note: In a past version of the proposal and in earlier implementations in Safari. `icon_variants` and `color_schemes` was used instead of `iconVariants` and `colorSchemes`.
 ```
 
 A benefit of this new structure is that it's more resilient to future changes,


### PR DESCRIPTION
As discussed in:
https://github.com/w3c/webextensions/issues/229#issuecomment-3383859384

To align with other extension APIs like `scripting.registerContentScripts()`, using camelCase when setting iconVariants instead of snake_case would align with existing patterns in webExtension API design.

This PR also adds a note on `NotificationOptions.iconVariants` as alternative for `NotificationOptions.iconUrl`.