### PR TITLE
Remove index.html from spec URL

### DIFF
--- a/specification/index.bs
+++ b/specification/index.bs
@@ -4,7 +4,7 @@ Shortname: webextensions
 Level: 1
 Status: w3c/CG-DRAFT
 Group: WECG
-URL: https://w3c.github.io/webextensions/specification/index.html
+URL: https://w3c.github.io/webextensions/specification/
 Editor: Mukul Purohit, Microsoft Corporation https://www.microsoft.com, mpurohit@microsoft.com
 Editor: Tomislav Jovanovic, Mozilla https://www.mozilla.org/, tjovanovic@mozilla.com
 Editor: Oliver Dunk, Google https://www.google.com, oliverdunk@chromium.org


### PR DESCRIPTION
As suggested in https://github.com/w3c/browser-specs/issues/2228#issuecomment-3548042857, drop the index.html ending from the path of our spec URL.

This is not necessary and was inconsistent with almost all other specs tracked by the W3C: https://w3c.github.io/browser-specs/index.json