### PR TITLE
User activation proposal

### DIFF
--- a/proposals/-user-activation-consumption.md
+++ b/proposals/-user-activation-consumption.md
@@ -1,0 +1,53 @@
+# Proposal: Rules for User Activation Consumption in WebExtensions
+
+This proposal is related to Issue #920: “Should extension APIs consume user activation?”
+
+## 1. Why this proposal?
+Some extension APIs should run only after a user gesture (click, keypress) for safety.  
+But other APIs need to run automatically (e.g., background tasks).  
+Currently, behavior is inconsistent across browsers.
+
+This proposal aims to define *clear rules*.
+
+## 2. API Categories
+
+### A. Critical / Intrusive APIs (should consume activation)
+- Opening new windows or tabs
+- Modifying browser UI
+- Clipboard read/write
+- Download requests
+
+These APIs should *require* and *consume* activation to avoid abuse.
+
+### B. Non-intrusive APIs (should not require activation)
+- Logging
+- Storage access
+- Messaging between extension contexts
+- Background listeners
+
+These APIs must continue to work *without activation*.
+
+## 3. Rules for Activation Consumption
+
+### Rule 1 — Only intrusive APIs consume activation
+- If an API changes user-visible UI or triggers navigation, it consumes activation.
+
+### Rule 2 — Passive APIs never consume activation
+- Background tasks do not consume or require activation.
+
+### Rule 3 — Clear documentation
+Browsers should publish:
+- Which APIs require activation  
+- Which APIs consume activation  
+- When activation expires  
+
+## 4. Benefits
+- More predictable behavior for users
+- Better consistency across Chrome, Firefox, Safari
+- Helps extension developers avoid confusion
+
+## 5. Conclusion
+This proposal suggests a balanced approach:
+- Restrict dangerous APIs  
+- Allow background tasks  
+- Provide documentation for developers

--- a/proposals/user-activation-consume.md
+++ b/proposals/user-activation-consume.md
@@ -1,0 +1,43 @@
+# Proposal: Rules for User Activation Consumption in WebExtensions
+
+## 1. Background
+Some APIs in WebExtensions currently require user activation (like a click), while others do not consume activation. This causes confusion and inconsistent behavior across browsers.
+
+## 2. Goals
+- Improve predictability for users
+- Maintain developer flexibility
+- Define clear rules on when activation must be consumed
+
+## 3. Proposed Rules
+
+### 3.1 APIs that MUST consume user activation:
+- Opening or closing tabs
+- Modifying tabs (move, update, reload)
+- Opening windows
+- Clipboard write access
+- Download initiation
+
+These are intrusive actions and should only run with explicit user consent.
+
+### 3.2 APIs that SHOULD NOT require user activation:
+- Background scripts
+- Scheduled alarms
+- Passive listeners
+- Sync storage
+- Message passing (runtime.sendMessage)
+
+These tasks are non-intrusive and should not break workflows.
+
+### 3.3 Possible Middle Ground
+Some APIs may depend on context. For example:
+- Popup → background script: may carry gesture for one transaction
+- Content script → background: should not carry activation (security risk)
+
+## 4. Documentation Needed
+Clear documentation is required for:
+- Which APIs consume activation
+- Which contexts allow gesture forwarding
+- How user activation is consumed per call
+
+## 5. Conclusion
+This proposal attempts to clarify activation rules and reduce confusion. Further discussion from the community is welcome.


### PR DESCRIPTION
This PR adds a proposal document describing rules for when WebExtension APIs
should consume user activation. The proposal covers:

- Intrusive APIs requiring activation
- Non-intrusive APIs not requiring activation
- Clear documentation needs
- A balanced approach for cross-browser consistency

This proposal is in response to Issue #920.
Feedback is welcome, and I’m happy to refine it further.