### PR TITLE
Publish minutes of 2026-03-12 meeting

### DIFF
--- a/_minutes/2026-03-12-wecg.md
+++ b/_minutes/2026-03-12-wecg.md
@@ -1,0 +1,130 @@
+# WECG Meetings 2026, Public Notes, Mar 12
+
+ * Chair: Kiara Rose
+ * Scribes: Rob Wu
+
+Time: 8 AM PDT = https://everytimezone.com/?t=69b35380,384
+Call-in details: [WebExtensions CG, 12th March 2026](https://www.w3.org/events/meetings/6a0eda89-558c-408d-b83d-5f03b8853c30/20260312T080000/)
+Zoom issues? Ping @zombie (Tomislav Jovanovic) in [chat](https://github.com/w3c/webextensions/blob/main/CONTRIBUTING.md#joining-chat)
+
+
+## Agenda: [discussion in #957](https://github.com/w3c/webextensions/issues/957), [github issues](https://github.com/w3c/webextensions/issues)
+
+The meeting will start at 3 minutes after the hour.
+
+See [issue 531](https://github.com/w3c/webextensions/issues/531) for an explanation of this agenda format.
+
+ * **Announcements** (2 minutes)
+   * [2026 London F2F Sign-up](https://docs.google.com/forms/d/e/1FAIpQLSedMSYmPll5cLMewS-Fn-HI2yD27OxNVzdVClYWDGF5lYcMNQ/viewform) ([coordination](https://github.com/w3c/webextensions/wiki/2026-London-F2F-Coordination), [topic discussion](https://github.com/w3c/webextensions/issues/951))
+ * **Triage** (15 minutes)
+   * [Issue 960](https://github.com/w3c/webextensions/issues/960): Proposal: limit length of extension action badge text
+ * **Timely issues** (10 minutes)
+   * N/A
+ * **Check-in on existing issues** (20 minutes)
+   * [Issue 935](https://github.com/w3c/webextensions/issues/935): Proposal: Limits on lengths of strings passed to WebExtension APIs
+   * [Issue 955](https://github.com/w3c/webextensions/issues/955): Alert users when an extension is disabled programmatically
+   * [Issue 934](https://github.com/w3c/webextensions/issues/934): Add runtime.getDocumentId() proposal
+
+
+## Attendees (sign yourself in)
+
+ 1. Rob Wu (Mozilla)
+ 2. Kiara Rose (Apple)
+ 3. Dave Vandyke (DuckDuckGo)
+ 4. Tim Judkins (Google)
+ 5. Oliver Dunk (Google)
+ 6. Benjamin Bruneau (1Password)
+ 7. Simeon Vincent (Unaffiliated)
+ 8. Tomislav Jovanovic (Mozilla)
+ 9. Maxim Topciu (AdGuard)
+ 10. David Johnson (Apple)
+ 11. Abishai Gray (Google)
+ 12. Mukul Purohit (Microsoft)
+ 13. Jordan Spivack (Capital One)
+ 14. Carlos Jeurissen (Jeurissen Apps)
+
+
+## Meeting notes
+
+[2026 London F2F Sign-up](https://docs.google.com/forms/d/e/1FAIpQLSedMSYmPll5cLMewS-Fn-HI2yD27OxNVzdVClYWDGF5lYcMNQ/viewform) ([coordination](https://github.com/w3c/webextensions/wiki/2026-London-F2F-Coordination), [topic discussion](https://github.com/w3c/webextensions/issues/951))
+
+ * [kiara] Reminder: London f2f meeting in April, please sign up if you are interested in attending.
+ * [rob] Recommendations for hotels in the area?
+ * [oliver] I found a hotel list. I'll add it to the wiki. The St Pancreas station and Google office have many hotels in the neighborhood.
+ * [tomislav] Is public transport reliable?
+ * [oliver] The underground (tube) is very reliable.
+
+[Issue 960](https://github.com/w3c/webextensions/issues/960): Proposal: limit length of extension action badge text
+
+ * [anton] setBadgeText can receive an arbitrary amount of text. The rendered text is displayed over extension icon in the browser chrome (as in the part of the browser UI with omnibox), so the rendered badge is smaller than even the extension icon. That works out to be always smaller than 100x100 px in size. There is no room for much text. Suggest to choose a limit.
+ * [simeon] Anton suggested a byte-based limit. That may cause potential issues with multi-byte unicode characters. We don't need to support an unlimited number of characters.
+ * [oliver] Would be interesting to see what we imagine this limit being. If the limit were 50 characters and the max size is 30x that size for large unicode characters, that seems reasonable.
+ * [kiara] Seems reasonable. Having a standard size we can apply to multiple APIs makes sense.
+ * [simeon] Don't think I included it in my last reply, but was thinking about something like 100 characters and 10 grapheme clusters as a combined limit.
+ * [tomislav] Getting into the details of unicode is perilous. Strongly suggest we avoid going that route.
+   * Background reading: https://hsivonen.fi/string-length/
+ * [rob] Can we just truncate, without throwing/rejecting from the API?
+ * [anton] Difficult to know how to correctly extract a sub-string. In order to do it well, you'd have to render the string to determine the effective characters.
+ * [rob] Would you prefer to throw an error or silently truncate?
+ * [anton] Thinking of silently ignoring the value for now (by just resolving the promise and hiding the badge). Throwing changes execution flow, truncating changes return value. Maybe change the behavior in a future manifest version?
+ * [tomislav] Added a doc (above in the note) from a colleague that goes into detail around challenges related to string handling. Suggest we have something like a limit of 1000 characters for the string and a separate limit for the number of characters shown. So two limits: how much we store and how much we display.
+ * [rob] I think that `action.setBadgeText()` is limited in practice, and there are no objections to enforcing some limit somewhere. If we are thinking about reasonable limits for APIs that take strings, we may also want to consider `action.setTitle()`. I tried just now to render 8k characters in Firefox, and a tooltip does show up with all of the specified text.
+ * [anton] Observed Chrome accepting unlimited input to `setTitle` and then reproducing it verbatim via `getTitle`, but having a display limit of 1024 bytes.
+ * [tomislav] By bytes, do you mean 2 bytes per JS character?
+ * [anton] I will prepare a test for the next meeting.
+ * [kiara] Next steps?
+ * [anton] I see that we need to align on a limit. Devlin and Oliver are reviewing my PR for collecting telemetry for a badge text histogram in Chromium.
+
+[Issue 935](https://github.com/w3c/webextensions/issues/935): Proposal: Limits on lengths of strings passed to WebExtension APIs
+
+ * [kiara] Did we get data on the lengths of alarms in practice?
+ * [anton] 1024 would be compatible with most extensions.
+ * [kiara] 1024 sounds good to us.
+ * [tomislav] Sounds good to us as well.
+ * [rob] Have you investigated the impact of rejecting on larger strings? E.g. by looking at a sample of extensions that trigger the limit.
+ * [anton] Haven't yet. Not sure how to find extensions that actually use these large strings.
+ * [rob] I consider the limit to be reasonable, but am concerned about suddenly breaking extensions that happen to hit this limit.
+ * [anton] There was a lengthy discussion between me and Oliver on the linked Chromium CL.
+ * [oliver] Breakage is a valid concern. Anyone setting a 1k+ alarm name should not have a reasonable expectation of it working forever.
+ * [rob] On the Firefox side we will likely take a wait and see approach.
+ * [rob] Are you able to detect via telemetry which extensions exceed the length?
+ * [oliver] We report histograms for all extensions, which aggregates data without identifying individual extensions.
+ * [anton] Perhaps reviewers can identify issues in new submissions?
+ * [rob] Issue with reviews and static analysis is that it's difficult to detect. If someone created an alarm based on the URL (which can be very long) an extension could break for no obvious reason.
+ * [anton] This will be deployed with a Finch flag to allow for staged rollout.
+ * [rob] We're specifically talking about the alarms API. Have we discussed a blanket limit on string sizes, e.g. 10k for all strings received in extension APIs unless a good reason is given otherwise? If we are doing narrow limits one API at a time, extensions would have to frequently update their extensions.
+ * [anton] Would be happy with that approach. Can always refine limits to adjust them as needed. Decided to go one API at a time because it seemed like a reasonable approach. I would expect alarms, action title, action badge text, etc. should have different limits.
+ * [rob] Browser vendors, thoughts on having such a default limit unless stated otherwise?
+ * [oliver] Anton, do you have context on why you are looking at these limits?
+ * [anton] I tried to play with extensions on mobile, and spotted issues related to memory usage. Discovered that memory in native code is shared among multiple extensions, and one faulty extension can affect many other extensions. Then I tried on desktop, and discovered that there is no practical limit. If you try to pass things that require terabytes of data, the browser would hang (fortunately not trying to fill the disk with terabytes of swap).
+ * [oliver] Going through all APIs is a lot of work, and we don't see abuse in practice. Willing to accept contributions. Setting a blanket 10k limit sound like a good solution.
+ * [oliver] How easy would it be on the Chrome side to enforce the limit in the API bindings?
+ * [anton] In Chromium, every ExtensionFunction's Run() method is part of an interface. There are also common macros.
+ * [rob] From the implementation point of view, if we want to add a default blanket limit it's feasible. In Firefox, we could specify differences in the JSON schema / IDL.
+ * [tim] (Nodding.)
+ * [oliver] If we did that, we'd want to go through the APIs and make sure we aren't enforcing limits in situations that would break things (e.g. storage).
+ * [kiara] Agreed.
+ * [rob] We would specify a default limit and allow overrides in specific APIs.
+ * [tomislav] Although JSON schemas allow limits to be specified, WebIDL does not. So if we want to align with web APIs, and move towards IDL, then having limits would interfere with that.
+ * [oliver] Sounds like we're heading in the right direction. Definitely a big architectural decision. Will want to follow up with the rest of the team.
+
+[Issue 955](https://github.com/w3c/webextensions/issues/955): Alert users when an extension is disabled programmatically
+
+ * [kiara] Discussed in the last meeting, with follow-up for Chrome.
+ * [oliver] I did not realize, but it turns out that Patrick had a CL showing in chrome://extensions/ that an extension was disabled by another extension.
+   * [\[Extensions\] Add warning when an extension is disabled by another.](https://crrev.com/c/6946079)
+ * [benjamin] I was thinking about something more obtrusive, but even having any feedback is already nice.
+ * [rob] In Firefox, we're thinking of requiring user interaction before an extension can disable another extension
+ * [oliver] I forgot to ask internally about requiring user interaction.
+ * [simeon] For clarity, does "requiring user interaction" mean requiring a user gesture or…
+ * [rob] When `management.setEnabled` is called, to show a prompt to the user to confirm enabling/disabling an extension.
+
+[IPR 934](https://github.com/w3c/webextensions/pull/934): Add runtime.getDocumentId() proposal
+
+ * [kiara] Asking other browser vendors to take a look.
+ * [simeon] **Meta discussion**: I'm a bit frustrated with our proposal process. I don't like having PRs open for long periods of time. Not clear what the meaning of a merged PR is: is it something we're all aligned on or is it something we're incubating?
+ * [rob] Would indeed be nice to not have many PRs stuck. We have said proposals shouldn't be aspirational. That implies that if something is merged, there is the expectation for the proposal to be implemented at the state that it is merged in.
+ * [carlos] It would be good to discuss the path/process from proposal to spec text at some point in the future.
+ * [oliver] Would be nice to merge and update as we go. But someone looking at a proposal / merged PR would have a reasonable expectation of it reflecting what we want.
+
+The next meeting will be on [Thursday, March 26th, 8 AM PDT (3 PM UTC)](https://everytimezone.com/?t=69c5c880,384).

--- a/_minutes/README.md
+++ b/_minutes/README.md
@@ -10,22 +10,23 @@ After the end of each meeting, meeting notes are published here.
 
 ## Upcoming meetings
 
-- 2026-03-12 at 8 AM PDT = https://everytimezone.com/?t=69b35380,384
 - 2026-03-26 at 8 AM PDT = https://everytimezone.com/?t=69c5c880,384
+- 2026-04-09 at 8 AM PDT = https://everytimezone.com/?t=69d83d80,3c0
 
 ## Past meetings
 
+* 2026-03-12 ([minutes](2026-03-12-wecg.md))
 * 2026-02-26 ([minutes](2026-02-26-wecg.md))
 * 2026-02-12 ([minutes](2026-02-12-wecg.md))
 * 2026-01-29 ([minutes](2026-01-29-wecg.md))
 * 2026-01-15 ([minutes](2026-01-15-wecg.md))
-* 2025-12-18 ([minutes](2025-12-18-wecg.md))
 
 <details>
 <summary><strong>All past meeting notes</strong></summary>
 
 **2026**
 
+* 2026-03-12 ([minutes](2026-03-12-wecg.md))
 * 2026-02-26 ([minutes](2026-02-26-wecg.md))
 * 2026-02-12 ([minutes](2026-02-12-wecg.md))
 * 2026-01-29 ([minutes](2026-01-29-wecg.md))


### PR DESCRIPTION
Generated from https://docs.google.com/document/d/1QkwhEMtMS67JBUkl_WVPZ4lRSKoWcQNlLJSf_GwSXg8/edit using the tool and process from https://github.com/w3c/webextensions/pull/105.

During this meeting we discussed or mentioned issues #957, #531, #951, #960, #935, #955 and PR #934.

Note: The Pacific time zone has recently shifted from Daylight Saving Time, but in Europe the Daylight Saving Time is still in effect. Double-check the time of the meeting if needed.