### PR TITLE
Publish minutes of 2026-04-09 meeting

### DIFF
--- a/_minutes/2026-04-09-wecg.md
+++ b/_minutes/2026-04-09-wecg.md
@@ -1,0 +1,148 @@
+# WECG Meetings 2026, Public Notes, Apr 9
+
+ * Chair: Kiara Rose
+ * Scribes: Rob Wu
+
+Time: 8 AM PDT = https://everytimezone.com/?t=69d83d80,384
+Call-in details: [WebExtensions CG, 9th March 2026](https://www.w3.org/events/meetings/6a0eda89-558c-408d-b83d-5f03b8853c30/20260409T080000/)
+Zoom issues? Ping @zombie (Tomislav Jovanovic) in [chat](https://github.com/w3c/webextensions/blob/main/CONTRIBUTING.md#joining-chat)
+
+
+## Agenda: [discussion in #969](https://github.com/w3c/webextensions/issues/969), [github issues](https://github.com/w3c/webextensions/issues)
+
+The meeting will start at 3 minutes after the hour.
+
+See [issue 531](https://github.com/w3c/webextensions/issues/531) for an explanation of this agenda format.
+
+ * **Announcements** (2 minutes)
+ * **Triage** (15 minutes)
+   * [Issue 967](https://github.com/w3c/webextensions/issues/967): Extension API to explicitly create split views or unsplit them
+   * [Issue 970](https://github.com/w3c/webextensions/issues/970): Should disabled extensions have their runtime.setUninstallURL opened on uninstall?
+   * [Issue 971](https://github.com/w3c/webextensions/issues/971): Proposal, targeted messaging `browser.runtime.sendMessage({target})`
+   * [Issue 972](https://github.com/w3c/webextensions/issues/972): Increase maximum number of disabled static rules from 5,000
+ * **Timely issues** (10 minutes)
+ * **Check-in on existing issues** (20 minutes)
+
+
+## Attendees (sign yourself in)
+
+ 1. Oliver Dunk (Google Chrome)
+ 2. Patrick Kettner (Google Chrome)
+ 3. Rob Wu (Mozilla)
+ 4. Tomislav Jovanovic (Mozilla)
+ 5. Kiara Rose (Apple)
+ 6. Carlos Jeurissen (Jeurissen Apps)
+ 7. Ben Greenberg (Aglide)
+ 8. Dave Vandyke (DuckDuckGo)
+ 9. Simeon Vincent (Independent)
+ 10. Benjamin Bruneau (1Password)
+ 11. Brandon Lucier (1Password)
+ 12. Dean Murphy (eyeo)
+ 13. Mukul Purohit (Microsoft)
+ 14. Casey Garland (Capital One)
+ 15. Thomas Greiner (eyeo)
+ 16. Timothy Hatcher (Apple)
+ 17. Tim Judkins (Google Chrome)
+
+
+## Meeting notes
+
+Recap of London F2F ([issue 951](https://github.com/w3c/webextensions/issues/951))
+
+ * [kiara] State of browsers, many issues triaged, discussed proposals. Discussed collaboration on maintaining a mapping of extensions across stores. On the Apple side we will create a repo to get started.
+ * [rob] Notes will be published shortly. In many cases, we summarized in a comment on the issue, but in some cases the meeting notes include additional discussion context.
+
+[Issue 967](https://github.com/w3c/webextensions/issues/967): Extension API to explicitly create split views or unsplit them
+
+ * [rob] May not be ready to discuss this. Does anyone use the feature?
+ * [casey] I do.
+ * [simeon] I do.
+ * [dave] I do.
+ * [rob] Would like to consider how to enable extensions to interact with this capability.
+ * [patrick] Are you thinking of it as a modifier to an existing API or a new method/namespace?
+ * [rob] Expanding the tabs namespace, add a new property to the tabs.create method to create a split view.
+ * [patrick] A couple of extension developers that want to use an API have requested it. One or two on the mailing list.
+ * [rob] I've also been in touch with some tab manager extensions. Sounds like we need a concrete proposal and then to gather feedback.
+ * [oliver] I think we're open to it. Was initially hesitant because it wasn't clear what the feature's future was, but seems to be getting adoption, so would like to improve extension support.
+ * [rob] I will work on a proposal.
+ * [tim] I believe there was a proposal for adding splitViewId to the tab object.
+ * [rob] Right. That's been implemented in Chrome and Firefox, but that only allows you to know about split views, doesn't allow you to create them. While working on split views, I also noticed additional complexity on moving tabs around, grouping, etc that were not covered by the initial proposal.
+
+[Issue 970](https://github.com/w3c/webextensions/issues/970): Should disabled extensions have their runtime.setUninstallURL opened on uninstall?
+
+ * [kiara] Discussed this week at the Face to Face. On the Safari side we don't support this. Tentatively neutral.
+ * [patrick] As opposed to opposed?
+ * [kiara] Personally hesitant. Not sure this functionality makes sense, but we already don't support it.
+ * [patrick] Unless someone's passionately for this, I'm inclined to be opposed.
+ * [oliver] Uninstall surveys are valuable for developers.
+ * [patrick] Is there a reason where, when a user has actively disabled something, and it gets uninstalled, it feels user-hostile to open the uninstall page.
+ * [dave] Search switch back prompt may also disable.
+ * [carlos] Doesn't seem additionally user hostile compared to just uninstallation.
+ * [timothy] Could see potentially waiting a few moments after disable. If uninstall occurs, then open the uninstall URL. After a period of being disabled, don't.
+ * [rob] It was mentioned this week that the uninstall URL persists across updates. I wouldn't do that.
+ * [oliver] If we go down the path of heuristics or session based behavior, I'm inclined to say we shouldn't specify.
+ * [patrick] Agree on not confiding specific heuristics, but saying something about short term
+ * [simeon] Worth noting that earlier this week we discussed onDisabled and onUninstalled events to allow pinging for telemetry purposes. That provides a similar signal without being as disruptive of an experience for the user.
+ * [carlos] Those would not allow developers to ask feedback from the user
+ * [rob] What about opening something specifically on disable?
+ * [patrick] Too much potential for abuse. “You have been hacked, must re-enabled!”
+ * [rob] I could see opening the uninstall page if the extension is disabled and then uninstalled during the same browser session. Low priority, but tentative plan.
+ * [thomas] useful to have some opportunity for feedback on uninstallation.
+ * [simeon] Firefox allows prompting about reporting malware when installing an extension, correct?
+ * [rob] In some circumstances.
+ * [mukul] As do Edge and Chrome.
+ * [simeon] Right. That goes back to the browser vendor. Could be a useful moment for the extension developer to get feedback.
+ * [carlos] Would like to have some chance to hear from the user, even if more limited than uninstall URL.
+ * [patrick] Having a browser provided form is preferable to no user feedback, correct?
+ * [carlos] Yes.
+ * [patrick] Might be worth going back to Justin to discuss the possibility of having a browser-provided form to gather some feedback. Move away from uninstalling the url entirely.
+ * [carlos] Utility not clear. May not be useful data.
+ * [thomas] Would need to have developer opt in.
+
+[Issue 971](https://github.com/w3c/webextensions/issues/971): Proposal, targeted messaging `browser.runtime.sendMessage({target})`
+
+ * [carlos] Apparently this is a duplicate. We talked about this in [issue 294](https://github.com/w3c/webextensions/issues/294) in 2022 before documentIds was defined. As an extension developer, you want a way to send messages to specific documents without having to know a specific tab ID. Resolves some issues related to using post message which is potentially unsafe.
+ * [simeon] I'm planning to work on a proposal to overhaul the extension messaging APIs.
+ * [carlos] Can we improve the existing `sendMessage`?  E.g. `documentId` as a target is supported by Safari only. Can we help?
+ * [simeon] I was planning to work on it next week, but also don't want to block this.
+ * [rob] I previously wrote my thoughts on this at [issue 293 (comment)](https://github.com/w3c/webextensions/issues/293#issuecomment-1310203017). I'd like to avoid broadcasts if possible, and reuse web primitives such as structured cloning and transferables.
+ * [kiara] Supportive.
+ * [devlin] We are broadly aligned on the change, webby things, definitely transferables. Getting rid of bidirectional broadcast.
+ * [simeon] Given that, any thoughts on targeting a specific context?
+ * [devlin] I'd rather a `contextId`.
+ * [simeon] Proposed is `documentId`, `targetId`, `tabId`, and `contextId` would be another one.
+ * [carlos] Could have a null `tabId` and add an option.
+ * [rob] We are also exploring `scripting.executeScript` without `tabId` .
+ * [devlin] Are we talking about `runtime.sendMessage` or `tabs.sendMessage`? `runtime.sendMessage` only delivers to extension origins, not isolated worlds.
+ * [carlos] Want to be able to
+ * [devlin] Is objective replacing messaging to content scripts?
+ * [carlos] Also frames.
+ * [devlin] Concretely, sending message from SW to iframe in a tab?
+ * [carlos] Supportive of additional targeting capabilities on existing APIs?
+ * [rob] I'm supportive of additional targeting capabilities. We've also discussed improvements. Have we considered supporting `MessagePort` from `MessageChannel` as a message in the current `sendMessage` APIs, provided that the message is delivered to one destination?
+ * [devlin] I'd be hesitant to do that. Seems like it could be an ugly bit of ducktape to make something work. Not familiar enough with Chrome's implementation to know if we'd be able to do that.
+ * [rob] Idea was cross origin frames are already supported on the web, so the implementation should already work for that. If I try hard to imagine potential issues, then I would think that they might be in a different browsing context group, which does not happen on the web. But from the serialization and hooking up perspective, the existence of cross-origin messaging is already a major solid building block.
+ * [devlin] Agree it's possible, don't know if it would be easy. I suspect it would be a large amount of refactoring to make it work. I can see it working, but it would likely be nontrivial. If we're going to take on that level of engineering work, would prefer to have a shape we like more.
+ * [dave] A while ago I made a little module to wrap passing messages to popups and such. I can share that if you're interested.
+ * [simeon] Yeah, would like to see what kind of usage patterns it enables.
+ * [rob] Carlos just updated the proposal to be specific to be a `tabs.sendMessage` method taking a `documentId` list without `tabId`. Supportive of that specific shape?
+ * [devlin] Yes.
+ * [kiara] Yes.
+ * [rob] Yes. But perhaps with the target object in the `tabId` field instead of filling in a dummy `null` in `tabId`?
+ * [kiara] In the interest of time, let's move on.
+
+[Issue 972](https://github.com/w3c/webextensions/issues/972): Increase maximum number of disabled static rules from 5,000
+
+ * [thomas] Following up to the discussion on 30,000 dynamic rules (319) after the limit was increased in Chrome and Safari and tentatively supportive in Firefox. There was related discussion at the last Ad Filtering Developer Summit. This issue breaks out the issue identified for consideration. Based on the data shared in the other issue, a doubling of the count would be suggested here.
+ * [devlin] In short, not much has changed since AFDS. It is already not guaranteed for rules to apply at startup, but with even more data it would become even less likely for rule initialization on browser startup becomes to finish (less likely that disabled rules would not be run as expected).
+ * [thomas] What I recall from when we investigated this is that we can't do anything about it and that it can take a long time to apply all rules. But open question about how much longer.
+ * [devlin] Even with small incremental additions, it delays the total time. Say rules apply 90% of the time, a small increase can lead to rules applying much less frequently (20%) despite not doubling in time. Staying under the ceiling is key.
+ * [dave] How much are you asking for?
+ * [thomas] Data seems to suggest doubling the limit to 10,000. But people like Fanboy know best here. If EasyList is aligned, we're likely good.
+ * [devlin] Could probably increase it significantly because we basically have to change out implementation to support a larger number. 5000 is essentially at the limit. If we're rearchitecting, we can probably make a larger improvement. But we'd also be paying a larger cost in total to make that work and slowing down initial load for everyone.
+ * [oliver] Currently there's no distinction between disabling a rule for a given reason. Having that information could allow for more selective application of rules.
+ * [thomas] Fanboy suggested there's also some automation occurring here. I do expect the volume to increase. Regardless of the limit, it will eventually be hit. The limit is currently so low as to exacerbate the issue.
+ * [rob] Would a more selective application of rules imply the API taking …
+ * [oliver] Developers should be able to make their own decision about how they want to prioritize disabling rules. Let's say there are 30k rules that don't do anything, they might get removed on GitHub, but there's no need to go through and disable all those rules because they don't do anything.
+
+The next meeting will be on [Thursday, April 23rd, 8 AM PDT (3 PM UTC)](https://everytimezone.com/?t=69eab280,3c0).

--- a/_minutes/README.md
+++ b/_minutes/README.md
@@ -10,23 +10,24 @@ After the end of each meeting, meeting notes are published here.
 
 ## Upcoming meetings
 
-- 2026-04-07 until 2026-04-09, face-to-face meeting in London ([issue 951](https://github.com/w3c/webextensions/issues/951))
-- 2026-04-09 at 8 AM PDT = https://everytimezone.com/?t=69d83d80,3c0
-- 2026-04-23 at 8 AM PDT = https://everytimezone.com/?t=69eab280,3c0
+- 2026-04-23 at 8 AM PDT = https://everytimezone.com/?t=69eab280,384
+- 2026-05-07 at 8 AM PDT = https://everytimezone.com/?t=69fd2780,384
 
 ## Past meetings
 
+* 2026-04-09 ([minutes](2026-04-09-wecg.md))
+* (minutes for the 2026-04-07 until 2026-04-09 face-to-face meeting in London will be published later and announced at [issue 951](https://github.com/w3c/webextensions/issues/951))
 * 2026-03-26 ([minutes](2026-03-26-wecg.md))
 * 2026-03-12 ([minutes](2026-03-12-wecg.md))
 * 2026-02-26 ([minutes](2026-02-26-wecg.md))
 * 2026-02-12 ([minutes](2026-02-12-wecg.md))
-* 2026-01-29 ([minutes](2026-01-29-wecg.md))
 
 <details>
 <summary><strong>All past meeting notes</strong></summary>
 
 **2026**
 
+* 2026-04-09 ([minutes](2026-04-09-wecg.md))
 * 2026-03-26 ([minutes](2026-03-26-wecg.md))
 * 2026-03-12 ([minutes](2026-03-12-wecg.md))
 * 2026-02-26 ([minutes](2026-02-26-wecg.md))


### PR DESCRIPTION
Generated from https://docs.google.com/document/d/1QkwhEMtMS67JBUkl_WVPZ4lRSKoWcQNlLJSf_GwSXg8/edit using the tool and process from https://github.com/w3c/webextensions/pull/105.

During this meeting we discussed or mentioned issues #969, #531, #967, #970, #971, #972, #951, #294, #293.