### PR TITLE
Add setUninstallURL to persistence-of-states table

### DIFF
--- a/memo/persistence-of-states.md
+++ b/memo/persistence-of-states.md
@@ -43,5 +43,6 @@ If developers want to keep states persistent across B, C or D, but the default p
 | proxy.settings.set() | | | |
 | [sidePanel.setPanelBehavior()](https://developer.chrome.com/docs/extensions/reference/sidePanel/#method-setPanelBehavior) | B + C + D | | |
 | privacy | B + C + D | B + C + D | Not supported |
+| [setUninstallURL](https://github.com/w3c/webextensions/issues/981) | B + C + D | A | No-op |
 
 \* This table may not be exhaustive, nor may it be adequately tested. Additions and corrections are welcome.


### PR DESCRIPTION
As discussed during the London F2F.

See also active discussion on setUninstallURL persistence:
https://github.com/w3c/webextensions/issues/981

Sidenote: we may want to consider a more semantic replacement for the A + B + C notation.