### PR TITLE
Drop publicSuffix.getVersion()

### DIFF
--- a/proposals/public-suffix.md
+++ b/proposals/public-suffix.md
@@ -400,9 +400,6 @@ namespace publicSuffix {
   )
   : string | null;
 
-  // Gets the value of the VERSION metadata field in the PSL dataset if available
-  export function getVersion(): string | null;
-
 
   // INTERFACES
 
@@ -761,22 +758,11 @@ It is noted that:
 In the future, if PSL lookups are resolved by way of DNS requests rather than by querying a
 browser-bundled PSL dataset (as is the case currently), then an async API may be a better fit.
 
-#### 11. PSL Version
-
-Versioning metadata was introduced into the PSL with [this commit](https://github.com/publicsuffix/list/issues/1808#issuecomment-2455793503).
-
-Method `getVersion()` of this API should return the value of the
-VERSION metadata field contained in the specific PSL dataset used by the browser.
-
 ### New Permissions
 
 | Permission Added | Suggested Warning |
 | ---------------- | ----------------- |
 | publicSuffix     | N/A               |
-
-Method `publicSuffix.getVersion()` may theoretically contribute to making the browser
-fingerprintable. However, it is already possible for malicious sites to get the browser's
-version, therefore this API does not introduce significant additional fingerprintability.
 
 ### Manifest File Changes
 
@@ -873,10 +859,6 @@ is provided for notifying extensions when the host browser's PSL dataset changes
 understood that such changes are only made currently when a new browser version
 is released, however this may not always be the case.
 
-It may be useful to implement a notification mechanism so that extensions can take
-appropriate action when the host browser's PSL dataset changes, to avoid having to
-poll the `getVersion()` function provided by this API.
-
 ### 3. Get Domain and Kind
 
 While API method `getDomain()` by default returns registrable domains,
@@ -895,3 +877,15 @@ An example use case would be if extension developers wanted to prepend
 additional labels to the domain returned by `getDomain()`. This would
 not make sense for returned IP addresses, so developers would need a
 way of separating returned IP addresses from returned domain names.
+
+### 4. Versioning
+
+The Public Suffix database includes a version field, introduced in
+https://github.com/publicsuffix/list/issues/1808#issuecomment-2455793503.
+
+An early draft of this proposal specified the `publicSuffix.getVersion()`
+method to retrieve that version. However, this method was dropped after
+feedback from implementers and PSL maintainers:
+
+- https://phabricator.services.mozilla.com/D295513#10264666
+- https://phabricator.services.mozilla.com/D295513#10434003


### PR DESCRIPTION
This is an update to the `publicSuffix` proposal to drop the specified `publicSuffix.getVersion()` method.

It was originally added in #676 following a request from @oliverdunk , referencing a PSL maintainer's request (quoted again at https://phabricator.services.mozilla.com/D295513#10264666 ):


> "Would you be open to adding a method to retrieve the PSL version in this proposal (I know it's mentioned in future work)? My understanding is that this currently doesn't exist, but the PSL maintainers have had requests for that in the past and were open to adding something. I'll let them know about this PR and perhaps they will have additional thoughts."

Another early position at https://github.com/w3c/webextensions/issues/231#issuecomment-2127529231 :

> Related, we should expose a list version to developers. There isn't currently an official version but Simone took an action item to investigate adding this as it has come up in the past.

Mozilla's PSL maintainer's recent position is as follows: https://phabricator.services.mozilla.com/D295513#10434003

> I am not a fan of providing a version. Mostly because it is not clear to me why this would be useful. Since fingerprinting is not a big issue for extensions I am not strongly opposed. Only from a "why build the API if it doesn't make sense" point.

@kzar is looking into a Chromium implementation, and mentioned the following:

> FWIW I was looking at the Chromium implementation recently, and so far my draft stubbed out `getVersion()` to always return null, as the version didn't seem to be available so far. Anything's possible, but if there's also difficulty adding this from the Firefox side as well, and as it's IMO not something most users of the API will need, dropping `getVersion()` for now seems pragmatic to me.