### PR TITLE
Publish minutes of 2026-06-04 meeting

### DIFF
--- a/_minutes/2026-06-04-wecg.md
+++ b/_minutes/2026-06-04-wecg.md
@@ -1,0 +1,197 @@
+# WECG Meetings 2026, Public Notes, June 4
+
+ * Chair: Kiara Rose
+ * Scribes: Rob Wu
+
+Time: 8 AM PDT = https://everytimezone.com/?t=6a221180,384
+Call-in details: [WebExtensions CG, 4th June 2026](https://www.w3.org/events/meetings/6a0eda89-558c-408d-b83d-5f03b8853c30/20260604T080000/)
+Zoom issues? Ping @zombie (Tomislav Jovanovic) in [chat](https://github.com/w3c/webextensions/blob/main/CONTRIBUTING.md#joining-chat)
+
+
+## Agenda: [discussion in #1003](https://github.com/w3c/webextensions/issues/1003), [github issues](https://github.com/w3c/webextensions/issues)
+
+The meeting will start at 3 minutes after the hour.
+
+See [issue 531](https://github.com/w3c/webextensions/issues/531) for an explanation of this agenda format.
+
+ * **Announcements** (2 minutes)
+   * It's Keynote season!
+ * **Triage** (15 minutes)
+   * [Issue 1004](https://github.com/w3c/webextensions/issues/1004): Inconsistency: Execution order for DNR modifyHeaders and webRequest.onBeforeSendHeaders
+   * [Issue 1005](https://github.com/w3c/webextensions/issues/1005): Deprecate author in favor of developer.name
+   * [Issue 1006](https://github.com/w3c/webextensions/issues/1006): Specify meaning of homepage_url and developer.url
+   * [Issue 1009](https://github.com/w3c/webextensions/issues/1009): When a webpage creates a same-origin document (iframe/popup/tab) the content scripts at document_start must run before the main world sees the document
+   * [Issue 1010](https://github.com/w3c/webextensions/issues/1010): Implement browser.menus.onShown
+   * [Issue 1011](https://github.com/w3c/webextensions/issues/1011): Proposal: runtime.getVersionName() method
+   * [Issue 1015](https://github.com/w3c/webextensions/issues/1015): action.setBadgeXXXX lacks context isolation between normal and Incognito/private windows
+   * [Issue 1016](https://github.com/w3c/webextensions/issues/1016): Service Worker / Event Page lifetime management during ongoing network requests (fetch / XHR)
+   * [Issue 1014](https://github.com/w3c/webextensions/issues/1014): AI inference in MV3 service workers: timeout interruption, no error signal, and the accessibility use case
+   * [Issue 1017](https://github.com/w3c/webextensions/issues/1017): modern ESM for content scripts and userscripts
+   * [Issue 1018](https://github.com/w3c/webextensions/issues/1018): Add support for history.addUrl({title, transition, visitTime})
+   * [PR 1019](https://github.com/w3c/webextensions/pull/1019): Add proposal for modifying split views
+ * **Timely issues** (10 minutes)
+   * N/A
+ * **Check-in on existing issues** (20 minutes)
+   * N/A
+
+
+## Attendees (sign yourself in)
+
+ 1. Rob Wu (Mozilla)
+ 2. Maxim Topciu (AdGuard)
+ 3. Brandon Lucier (1Password)
+ 4. Benjamin Bruneau (1Password)
+ 5. Hilary Hacksel (1Password)
+ 6. Patrick Kettner (Google Chrome)
+ 7. Tomislav Jovanovic (Mozilla)
+ 8. Tim Judkins (Google)
+ 9. Ben Greenberg (Aglide)
+ 10. Simeon Vincent (unaffiliated)
+ 11. Carlos Jeurissen (Jeurissen Apps)
+ 12. David Hénot (Dashlane)
+ 13. David Johnson (Apple)
+ 14. Kiara Rose (Apple)
+ 15. Mukul Purohit (Microsoft)
+ 16. Timothy Hatcher (Apple)
+ 17. Dave Vandyke (DuckDuckGo)
+ 18. Jordan Spivack (Capital One)
+
+
+## Meeting notes
+
+Keynotes
+
+ * [kiara] Google I/O was recently, Apple WWDC is coming up.
+ * [patrick] [Extensions @ Google I/O talk](https://io.google/2026/explore/technical-session-19)
+
+[Issue 1004](https://github.com/w3c/webextensions/issues/1004): Inconsistency: Execution order for DNR modifyHeaders and webRequest.onBeforeSendHeaders
+
+ * [kiara] Question is whether headers should be modified by DNR before or after firing onBeforeSendHeaders. Firefox and Safari modify headers before firing the event, Chrome does it after.
+ * [carlos] Also for response headers. Rob made a point on Firefox's issue tracker that modifying with DNR upfront enables extensions to modify the header at runtime. I believe it makes sense to have declarative changes before non-declarative changes make the most sense. However I wonder if other than knowing the inconsistencies, there are real use cases for the current order to change.
+ * [rob] Applying DNR rules upfront was indeed an intentional aspect, and also in line with other aspects of the browser that include headers before extensions can see it (e.g. cookies).
+ * [kiara] Agree that it makes sense for DNR modifications to occur first. Developer opinions?
+ * [carlos] Could ask in the issue if there's a use case to change this behavior.
+ * [rob] I don't see a reason to change it on Firefox.
+ * [tim] I'll raise this with folks that have been working on DNR to get their input.
+ * [rob] I see a possible argument in Chrome for the relationship between onBeforeHeaders with blocking webRequest: if blocking webRequest does not exist, then onBeforeSendHeaders and onSendHeaders would have the same header information. But enterprise extensions can still use blocking webRequest.
+ * [kiara] I'll add a follow-up for Chrome and add it to the next agenda.
+
+[Issue 1005](https://github.com/w3c/webextensions/issues/1005): Deprecate author in favor of developer.name
+
+ * [kiara] I think we'd be neutral since we don't support `author`.
+ * [carlos] I think you're correct that authors isn't currently used in any browser. Seems like an artifact from old pre-Chromium Edge.
+ * [rob] Firefox does use it, but is only used in case `developer.name` is missing, so no concerts with its removal if others agree.
+ * [patrick] I believe we'd be supportive but need to double check.
+
+[Issue 1006](https://github.com/w3c/webextensions/issues/1006): Specify meaning of homepage_url and developer.url
+
+ * [carlos] Currently `homepage_url` is used in some extensions for the website and `developer.url` is used for the same thing. I think we can specify which value is meant for what scenario.
+ * [simeon] I'm supportive of cleaning this up. Been a while since I last looked into this, but as I recall it's inconsistent across browsers. It would be nice to have clarity.
+ * [rob] Agreed.
+
+[Issue 1009](https://github.com/w3c/webextensions/issues/1009): When a webpage creates a same-origin document (iframe/popup/tab) the content scripts at document_start must run before the main world sees the document
+
+ * [kiara] Some user scripts not guaranteed to run early, extensions like Tampermonkey need to run first.
+ * [rob] I think we try to guarantee this as much as we can, but in practice all browsers cannot guarantee it.
+ * [kiara] Agree. Don't know if there's anything more we can do on our end to make this experience better.
+ * [dave] This is something websites use all the time to get past ad blockers. Do we know how they're seeing it go wrong? Maybe concrete examples would help.
+ * [simeon] Why is this case (same origin document creation) a particular problem?
+ * [rob] Not same origin. It's the creation of a frame they directly control.
+ * [simeon] Is this something we could work with WHATWG to work through?
+ * [rob] No, implementation detail in extensions. We have also had this discussion/topic multiple times before, each time with the same conclusion: implementation infeasibility.
+
+[Issue 1010](https://github.com/w3c/webextensions/issues/1010): Implement browser.menus.onShown
+
+ * [kiara] This is an event we don't support in Safari, but seems useful for developers to get more flexibility. Tentatively supportive.
+ * [rob] Firefox implements. I added [a comment](https://github.com/w3c/webextensions/issues/1010#issuecomment-4566118975) with a few more methods related to dynamic menus.
+ * [simeon] As I recall Chrome had concerns with context menus not being able to be updated at the OS level after being opened, which meant introducing delays. I believe there were concerns with delays that would introduced.
+ * [rob] Firefox had similar concerns initially, but in practice it is not an issue. One mitigating aspect for the implementation is that extensions can only have one top-level menu item. Even if they dynamically update menu items, that would not cause top-level menu items to shift. The separate `menus.overrideContext()` method permits extensions to control the menu in their own page, potentially the full menu, but at that point it is their own context menu.
+
+[Issue 1011](https://github.com/w3c/webextensions/issues/1011): Proposal: runtime.getVersionName() method
+
+ * [rob] When we discussed this before we found some utility in the version specifically. What additional value is there for additional static manifest fields? I personally haven't found value in this capability. Perhaps others can share more?
+ * [kiara] Requesting commonly used manifest keys without requiring the whole manifest to be read.
+ * [carlos] Same argument was why we added `runtime.getVersion()`.
+ * [rob] `runtime.getVersion()` can be normalized, which can be potentially different from `runtime.getManifest()`.
+ * [carlos] Could potentially be useful for libraries? I don't feel strongly.
+ * [rob] Not in favor of this method. Doesn't feel like much general utility and it can already be retrieved.
+ * [carlos] Goal with adding methods was to reduce the need to load the whole manifest.
+ * [rob] With that constraint, can make the extension name localized and use `i18n.getMessage()` to look up the extension name. I see multiple other ways to accomplish this, and believe that the utility of `runtime.getVersionName()` is limited, and therefore I'm opposed.
+ * [dave] Version is useful for comparing semantic versions. If we add this, maybe we should consider adding version comparison methods.
+ * [carlos] I've also had challenges with comparing version numbers. Common in mobile apps to have an integer version. Could be a next manifest version.
+ * [tomislav] Are you suggesting limiting version to be only a number?
+ * [carlos] Yes.
+ * [tomislav] Goes against the broader pattern in software. I believe in Firefox we've simplified the version field to only accept numerics. That should be easy enough to compare. Don't think we'd ever move to a single version number in the future.
+ * [rob] Getting back to the original issue, what should we do here?
+ * [kiara] We wouldn't strongly push for this method, but maybe if `getManifest()` were to be dropped we could consider dropping it. Neutral.
+ * [tim] Good point. If there's no other way to get it, makes sense to have it. If there already is a way to get it, doesn't seem to be much benefit. Neutral.
+
+[Issue 1015](https://github.com/w3c/webextensions/issues/1015): action.setBadgeXXXX lacks context isolation between normal and Incognito/private windows
+
+ * [kiara] Sounds like a Chrome-specific issue.
+ * [carlos] Window-specific properties is one part, not supporting incognito-specific context is the other issue. Point of `incognito:split` is that properties ought to be separate.
+ * [tim] Sounds like a bug. Definitely file something for that.
+ * [carlos] Already an issue linked in the discussion: https://issues.chromium.org/issues/41455158
+ * [carlos] Would Google be supportive of adding window-specific properties?
+ * [patrick] Wouldn't be against it, but also not prioritizing it.
+
+[Issue 1016](https://github.com/w3c/webextensions/issues/1016): Service Worker / Event Page lifetime management during ongoing network requests (fetch / XHR)
+
+ * [kiara] Requests taking longer than 30 seconds risk the background page being terminated. Seems like previous discussions around `waitUntil` could address this.
+ * [rob] I see that I forgot to put up a proposal for `waitUntil`, despite all browsers having expressed support for it.
+   * https://github.com/w3c/webextensions/issues/416
+ * [rob] Andrea from Google recently submitted a proposal relating to the lifetime https://github.com/w3c/webextensions/pull/989. I'm wondering if there is still an appetite for the functionality on Google's end.
+ * [simeon] That was my main concern with Google's proposal. My understanding from conversation with Googlers was that `waitUntil` and other options are still very much on the table.
+ * [kiara] Next steps?
+ * [rob] Anyone can create a proposal with the desired semantics in order to contain the discussion would be useful to push this forward. I have definitely seen extensions using keepalive hacks to prolong the lifetime. Are developers here that would like this functionality?
+ * [tomislav] Does anyone currently use the hacky way of prolonging life.
+ * [benjamin] I believe we have a heartbeat. Generally we do enough work to keep our extension active.
+ * [brandon] We use it. Early on it was a huge issue.
+ * [timothy] Looking forward, there's a legitimate case around local AI models needing more time.
+ * [patrick] 30 second lifetime is not a hard limit any more, but 30 seconds of idle. We watch a number of signals to determine whether something is considered idle. May just be a bug in our classification.
+ * [dave] I believe messaging API extends it for up to 5 minutes and terminates.
+ * [patrick] There's 5 minute timeout for unsupervised activity in Chrome. I think it's in Gemini, but not my area of expertise.
+
+[Issue 1014](https://github.com/w3c/webextensions/issues/1014): AI inference in MV3 service workers: timeout interruption, no error signal, and the accessibility use case
+
+ * [rob] We just discussed this, and `waitUntil` would cover this. Do we want to do something special for this use case, or just refer to `waitUntil`?
+ * [kiara] If `waitUntil` addresses this, then we can resolve this.
+ * [patrick] On the Chrome side we would see this as a bug and change our implementation, independently of `waitUntil` support.
+ * [rob] Makes sense. If users use AI and want to use their hardware for this, trying to shut down the background to conserve resources doesn't necessarily make sense.
+
+[Issue 1017](https://github.com/w3c/webextensions/issues/1017): modern ESM for content scripts and userscripts
+
+ * [rob] Duplicate of https://github.com/w3c/webextensions/issues/156
+ * [simeon] Right, I think we've said in the past that this would be nice to have.
+ * [tomislav] I think we've fixed this in Firefox?
+ * [rob] We have dynamic imports, but not static imports. Also in relation to the earlier topic today, running as early as possible at document start would be challenging in combination with static imports.
+ * [dave] Would be okay to have carve outs that would allow the script to be run. Those kind of extensions may just want to ensure that a dependency is loaded.
+ * [simeon] Interesting point. If declaring a content script as a module caused document_start to be missed, that could be a footgun.
+ * [kiara] Stances?
+ * [rob] Supportive. I'll update the original issue.
+
+[Issue 1018](https://github.com/w3c/webextensions/issues/1018): Add support for history.addUrl({title, transition, visitTime})
+
+ * [patrick] I think we do support this and MDN may be wrong. According to our docs at least.
+ * [rob] Checking Chrome's documentation, the details definition only contains `url`.
+ * [patrick] Apologies, you're right. This would be a Chrome feature request. Don't see a problem with adding it, but doubt we'd prioritize.
+ * [tim] We may want to look into whether there was a particular reason it was only URL.
+
+[PR 1019](https://github.com/w3c/webextensions/pull/1019): Add proposal for modifying split views
+
+ * [rob] Got this created just before this meeting. Would like to see if we can align on the shape of creating split views. Hoping we can avoid creating a bunch of new APIs similar to how we did with tab groups. My proposal introduces methods to create split views, joining split views, and separating them. For reference, split views are a recent feature in browsers that allow the browser to show two pages in the same window.
+ * [rob] To open a split view with one existing tab, I propose adding `tabs.create` with a `splitViewId` property. It validates constraints making sure the tab can go in the split view. More details in the proposal itself. Open to bikeshedding names.
+ * [rob] `tabs.createSplitView` takes two tabs and displays them together. The bare minimum is the ability to join two adjacent tabs. There's also the possibility of moving them, but I don't require that in the initial proposal.
+ * [simeon] Is the proposal limited to 2 tabs?
+ * [rob] Currently has an array of 2 tabs. Tried to be forward looking and allow for the possibility of adding more tabs to the split and specifying position.
+ * [carlos] Should the `tabs.create` method accept an array for `splitWithTabId` to support adding tabs to multiple split views in that case?
+ * [rob] For anything more advanced I would suggest the use of `tabs.createSplitView`. The main purpose of having a `tabs.create` method at all is that it is a common operation and allows browsers to show the special new split page rather than defaulting to new tab.
+ * [ben] Is there a way to identify tabs in a split view?
+ * [rob] This proposal builds upon an earlier proposal from Google, which introduced only a read-only way to detect the presence of split views. Googlers, could you have someone look into this proposal and share feedback on the general shape?
+ * [tim] Can do.
+
+Outro:
+
+ * [kiara] Fun fact: The first issue ([issue 1](https://github.com/w3c/webextensions/issues/1)) was created 5 years ago.
+
+The next meeting will be on [Thursday, June 18th, 8 AM PDT (3 PM UTC)](https://everytimezone.com/?t=6a348680,384).

--- a/_minutes/README.md
+++ b/_minutes/README.md
@@ -10,11 +10,12 @@ After the end of each meeting, meeting notes are published here.
 
 ## Upcoming meetings
 
-- 2026-06-04 at 8 AM PDT = https://everytimezone.com/?t=6a221180,384
 - 2026-06-18 at 8 AM PDT = https://everytimezone.com/?t=6a348680,384
+- 2026-07-02 at 8 AM PDT = https://everytimezone.com/?t=6a46fb80,384
 
 ## Past meetings
 
+* 2026-06-04 ([minutes](2026-06-04-wecg.md))
 * 2026-05-21 ([minutes](2026-05-21-wecg.md))
 * 2026-05-07 ([minutes](2026-05-07-wecg.md))
 * 2026-04-23 ([minutes](2026-04-23-wecg.md))
@@ -22,13 +23,13 @@ After the end of each meeting, meeting notes are published here.
 * 2026-04-09 F2F meetup in London ([minutes](2026-04-09-london-f2f.md))
 * 2026-04-08 F2F meetup in London ([minutes](2026-04-08-london-f2f.md))
 * 2026-04-07 F2F meetup in London ([minutes](2026-04-07-london-f2f.md))
-* 2026-03-26 ([minutes](2026-03-26-wecg.md))
 
 <details>
 <summary><strong>All past meeting notes</strong></summary>
 
 **2026**
 
+* 2026-06-04 ([minutes](2026-06-04-wecg.md))
 * 2026-05-21 ([minutes](2026-05-21-wecg.md))
 * 2026-05-07 ([minutes](2026-05-07-wecg.md))
 * 2026-04-23 ([minutes](2026-04-23-wecg.md))


### PR DESCRIPTION
Generated from https://docs.google.com/document/d/1QkwhEMtMS67JBUkl_WVPZ4lRSKoWcQNlLJSf_GwSXg8/edit using the tool and process from https://github.com/w3c/webextensions/pull/105.

During this meeting we discussed or mentioned issues #1003, #531, #1004, #1005, #1006, #1009, #1010, #1011, #1015, #1016, #1014, #1017, #1018, #416, #156 and PRs #1019, #989.

We also mentioned #1 because we just crossed the 5-year anniversary of the first issue!