### PR TITLE
Publish minutes of 2026-06-25 WEWG meeting

### DIFF
--- a/_minutes/2026-06-25-wewg.md
+++ b/_minutes/2026-06-25-wewg.md
@@ -1,0 +1,100 @@
+# WEWG Meetings 2026, Public Notes—June 25, 2026
+
+ * Chair: Simeon Vincent
+ * Scribes: Rob Wu
+
+Time: 8 AM PDT = https://everytimezone.com/?t=6a3dc100,384
+Call-in details: [WEWG Calendar](https://www.w3.org/groups/wg/webextensions/calendar/)
+Zoom issues? Ping @zombie (Tomislav Jovanovic) in [chat](https://github.com/w3c/webextensions/blob/main/CONTRIBUTING.md#joining-chat)
+
+
+## Agenda
+
+ * First WEWG meeting! No pre-defined agenda for this first meeting.
+
+
+## Attendees (sign yourself in)
+
+ 1. Rob Wu (Mozilla)
+ 2. Kiara Rose (Apple)
+ 3. Timothy Hatcher (Apple)
+ 4. David Johnson (Apple)
+ 5. Tomislav Jovanovic (Mozilla)
+ 6. Simeon Vincent (invited expert)
+ 7. Carlos Jeurissen (invited expert)
+ 8. Jordan Spivack (Capital One)
+ 9. Sarven Capadisli (Invited Expert, TAG, dokieli)
+ 10. Benjamin Bruneau (1Password)
+ 11. Mukul Purohit (Microsoft)
+ 12. Devlin Cronin (Google)
+ 13. Tim Judkins (Google)
+
+
+## Meeting notes
+
+Minutes
+
+ * [simeon] Meeting notes - doc currently restricted, does not need to be. Recording minutes is recommended, decisions (SHOULD, MUST, etc) and their rationale (if not obvious) need to be published.
+ * [timothy] Public is fine.
+ * [rob] Publishing would be fine to me too. Do we use the same repo we already have?
+ * [simeon] Any concerns with defaulting to public? None observed. Let's proceed with that.
+ * [rob] We can tweak the naming scheme for WG meetings, `_minutes/DATE-wecg.md` -> `_minutes/DATE-wewg.md`.
+ * [sarven] It would serve us as well as the W3C community well if we record some decisions, does not need to be at the detail of who said what, as long as the details are recorded.
+ * [simeon] We err on the side of transcript detail.
+
+WG vs CG Repository
+
+ * [timothy] On that topic; recently got a notification about the intent to move w3c to w3c-cg. I'd like to maintain the same repo if we can.
+ * [rob] Where?
+ * [simeon] Chairs email. We can create an issue to discuss.
+ * [carlos] The WECG has many issues and links that would be invalidated if the repo were to move.
+ * [rob] I have a strong preference to maintain the current repository if we can.
+ * [tomislav] CG can decide how to do the repo, and e.g. link to the current repo.
+ * [rob] WG is chartered for a given period. If uncharted what happens to the current repo repo? I'd like the basis for the existence of the repo to not be dependent on the WG. 1) Can we continue using the current repo for the CG 2) Can the same repo be used for both groups?
+ * [simeon] I'd also prefer to keep them combined. Historical expectation is that we can combine them, but haven't read the email yet. Timothy and I will need to follow up. We will discuss further in the CG.
+ * [timothy] Sounds like they're trying to move everyone. Unfortunate as it will break links.
+ * [sarven] W3C does provide that org, but CGs are not required to use them. Eventually licensing issues: is a contribution to a repo part of a “wider web project” or a “W3C umbrella”? A cg-specific repo makes that distinction more clear. But if a group needs to have the right copyright etc, then it would be better to include it under the w3c org. Not sure if required though. When snapshotted, it doesn't matter whether it is a CR or snapshot, but publishing rules are validated (pubrules). IPR is an agreement to go with it. A contributor submitting a PR, then a question is whether it is a substantial contribution, and if yes, they need to be part of the group and waive rights. But an editorial / minor change can come from anyone.
+ * [rob] Does this require a separate repository, or can we make the rules apply to a separate subdirectory, for example?
+ * [tomislav] Not required, but it should be clear what's under what set of rules, how contributions to each group are handled. For example, proposals probably shouldn't be shared between the groups. We should have clearer terminology around proposals at each stage.
+ * [rob] Duplicating the same proposal in 2 places isn't the best way to keep the relevant info clear and up to date. In the CG we haven't retroactively updated proposals after implementation. Do we need to have a proposal in the WG? We ultimately need to deliver specifications, not WIP proposal artifacts, right?
+ * [simeon] If we have separate groups, the way I see it working is that the CG produces versioned artifacts that are sent to the WG for review, WG assesses and renders a verdict (accept, request changes, reject).
+ * [sarven] I would caution that the optics should not be that this group exists to rubber stamp the work that incubated in the CG. Recommend to be clear on what the handover from the CG to WG is. The role of the WG is to take mature ideas, evaluate them, and integrate them into the specification. (Related on rubber stamping: https://www.w3.org/guide/standards-track/#is-it-clear-the-proposers-are-not-seeking-a-rubber-stamp-from-w3c but not strictly applicable to this WG charter)
+ * [tomislav] Good point. I think it's fine for the WG to incubate in the CG, but that should not be exclusive (work from other groups should be welcome as well).
+ * [rob] Weakness of the CG is that we've so far produced very few specifications. That is what we'd like to improve in the WG, and a clear scope under the umbrella of the WG.
+ * [simeon] Role of editors is to work on the spec; If an editor is not producing work, should we replace them? (question, not leading question)
+ * [tomislav] Role of editor is to shepherd / approve the work. Text comes from many people, and the editor is ultimately the overseer.
+ * [simeon] Indeed, editors are not spec machines.
+ *
+ * [tomislav] Sarven, is there guidance on the split between CG and WG?
+ * [sarven] https://github.com/w3c/cg-program/blob/main/proposals/spec-lifecycle.md is one consideration. There's also a CG Program community group: https://www.w3.org/groups/cg/council/ . Take these resources with a grain of salt. Nothing is written in stone.
+ * [tomislav] Multi-implementer interest is required for WG, but not CG artifacts.
+ * [sarven] https://www.w3.org/policies/process/#adequate-implementation
+
+WG organization
+
+ * [simeon] WG and CG - what work are we doing where?
+ * [simeon] The CG is continuing what it does now; The WG focuses on formally specifying. WG focused on proposals, concrete feedback of proposals (e.g. Reject - with rationale, Accept - towards merging, Request for revision - with material feedback from us).
+ * [rob] By proposal do you mean proposals in the format that we have seen in the CG, or a proposal to modify the “specification”?
+ * [simeon] I'm specifically thinking of substantive spec text revisions.
+ * [rob] For context, CG proposals
+ * [simeon] Thinking of CG producing proposals, and having the WG do an assessment of the proposal to see if we can adopt it. Proposal in CG is relatively loose; in WG we would discuss and merge a proposal. And then turn the proposal into specification text, a living standard.
+ * [timothy] Matches my mental model for the setup of the groups: taking loose proposals in the CG, and then move to the WG to incorporate in the spec text.
+ * [sarven] My reading of the WG charter is that incubating in the CG, and working towards publishing snapshots in the WG sounds good, in addition to whatever adequate implementation experience is deemed sufficient to make those snapshot releases. ( https://www.w3.org/policies/process/#publishing-crrs )
+ * [simeon] The snapshot process described in the charter is based on the most recent guideline from the W3C I could find on a living spec.
+
+Next steps
+
+ * [rob] What do we want to achieve before the next meeting in 4 weeks?
+ * [simeon] Concrete clarity on the repository location. And also the work of this group. I'll draft something to prepare for review by the next meeting. Will also aim to clarify the line between the groups.
+ * [rob] Chair of the WEWG meetings, alternate between Timothy and Simeon (in the CG we alternative between Kiara and Simeon, but I don't know if the WG has stricter requirements).
+ * [timothy] I can chair the next meeting.
+
+Action items
+
+ * [Assignee] Task (Requester)
+ * [simeon] Document WG process we've discussed in this meeting. (simeon)
+ * [simeon] Review Sarven's resources and define a line between CG and WG. (simeon)
+ * [simeon,timothy] Get clarity on whether we can re-use the existing repository (rob)
+ * [simeon] Review process docs and share an update next meeting on how chairing responsibilities are handled.
+
+The next WEWG meeting will be on [Thursday, July 23th, 8 AM PDT (3 PM UTC)](https://everytimezone.com/?t=6a62ab00,384).

--- a/_minutes/README.md
+++ b/_minutes/README.md
@@ -1,20 +1,31 @@
 # Meetings
 
-The [WebExtensions Community group](https://www.w3.org/community/webextensions/) meets virtually every other week, for one hour.
-The instructions to join the meeting and agenda are available at https://www.w3.org/groups/cg/webextensions/calendar.
+The [WebExtensions Community group](https://www.w3.org/community/webextensions/) (WECG) meets virtually every other week, for one hour.
+Upcoming CG meetings and instructions to join them are at https://www.w3.org/groups/cg/webextensions/calendar/.
 
 * Thursday 8 AM PDT (3 PM UTC)
 * To convert to your local time zone, see https://everytimezone.com/
+
+The [WebExtensions Working Group](https://www.w3.org/groups/wg/webextensions/) (WEWG) meets virtually every four weeks, for one hour (when the WECG is not meeting).
+Upcoming WG meetings and instructions to join them are at https://www.w3.org/groups/wg/webextensions/calendar/.
 
 After the end of each meeting, meeting notes are published here.
 
 ## Upcoming meetings
 
+The agenda for upcoming meetings is prepared in [issues with `label:agenda`](https://github.com/w3c/webextensions/issues?q=is%3Aissue%20state%3Aopen%20label%3Aagenda).
+
 - 2026-07-02 at 8 AM PDT = https://everytimezone.com/?t=6a46fb80,384
 - 2026-07-16 at 8 AM PDT = https://everytimezone.com/?t=6a597080,384
+- 2026-07-23 WEWG meeting: https://everytimezone.com/?t=6a62ab00,384
+
+Calendars:
+- https://www.w3.org/groups/cg/webextensions/calendar/ (Community Group)
+- https://www.w3.org/groups/wg/webextensions/calendar/ (Working Group)
 
 ## Past meetings
 
+* 2026-06-25 WEWG meeting ([minutes](2026-06-25-wewg.md))
 * 2026-06-18 ([minutes](2026-06-18-wecg.md))
 * 2026-06-04 ([minutes](2026-06-04-wecg.md))
 * 2026-05-21 ([minutes](2026-05-21-wecg.md))
@@ -26,6 +37,7 @@ After the end of each meeting, meeting notes are published here.
 
 **2026**
 
+* 2026-06-25 WEWG meeting ([minutes](2026-06-25-wewg.md))
 * 2026-06-18 ([minutes](2026-06-18-wecg.md))
 * 2026-06-04 ([minutes](2026-06-04-wecg.md))
 * 2026-05-21 ([minutes](2026-05-21-wecg.md))


### PR DESCRIPTION
*Generated from https://docs.google.com/document/d/1ezXs4uJzbfi8nyncUQcFLDyS9Tn_trs9j_RQgM54GBE/edit using the tool and process from https://github.com/w3c/webextensions/pull/105 (adapted for the [WebExtensions Working Group](https://www.w3.org/groups/wg/webextensions/) (WEWG)).*

This was the first WebExtensions Working Group (WEWG) meeting, distinct from the Community Group (CG). The processes, artifact locations are not yet fixed, but for now we will use the meeting conventions that we have been using for the WECG. I also added some details on the upcoming WECG meetings to `_minutes/README.md`.

Action items:
- [simeon] Document WG process we’ve discussed in this meeting. (simeon)
- [simeon] Review Sarven’s resources and define a line between CG and WG. (simeon)
- [simeon,timothy] Get clarity on whether we can re-use the existing repository (rob)
- [simeon] Review process docs and share an update next meeting on how chairing responsibilities are handled.
