### PR TITLE
Publish minutes of 2026-08-13 meeting

### DIFF
--- a/_minutes/2026-08-13-wecg.md
+++ b/_minutes/2026-08-13-wecg.md
@@ -1,0 +1,183 @@
+# WECG Meetings 2026, Public Notes, August 13
+
+ * Chair: Simeon Vincent
+ * Scribes: Rob Wu
+
+Time: 8 AM PDT = https://everytimezone.com/?t=6a7e5a80,384
+Call-in details: WebExtensions CG, 13th August 2026
+Zoom issues? Ping @zombie (Tomislav Jovanovic) in [chat](https://github.com/w3c/webextensions/blob/main/CONTRIBUTING.md#joining-chat)
+
+
+## Agenda: [discussion in #1053](https://github.com/w3c/webextensions/issues/1053), [github issues](https://github.com/w3c/webextensions/issues)
+
+The meeting will start at 3 minutes after the hour.
+
+See [issue 531](https://github.com/w3c/webextensions/issues/531) for an explanation of this agenda format.
+
+ * **Announcements** (2 minutes)
+   * [w3c/tpac2026-meetings#70 (comment)](https://github.com/w3c/tpac2026-meetings/issues/70#issuecomment-5133840941): CG members can't currently register for TPAC
+   * @dotproto published up [webextensions.group](https://webextensions.group/) (repo)
+   * Microsoft Edge announced MV2 deprecation (at end of meeting).
+ * **Triage** (15 minutes)
+   * [Issue 1054](https://github.com/w3c/webextensions/issues/1054): Allow extensions to inject content scripts into sandboxed extension pages (@Robbendebiene)
+   * [Issue 1055](https://github.com/w3c/webextensions/issues/1055): Inconsistency: Return value for alarms.clearAll() (@kiaraarose)
+   * [Issue 1056](https://github.com/w3c/webextensions/issues/1056): Inconsistency: runtime.getPlatformInfo() (@bershanskiy)
+   * [Issue 1058](https://github.com/w3c/webextensions/issues/1058): Inconsistency: proxy.settings (@erosman)
+ * **Timely issues** (10 minutes)
+   * [Issue 940](https://github.com/w3c/webextensions/issues/940): Provide a way to distinguish prefetch requests from regular navigations in extension APIs (@oliverdunk)
+ * **Check-in on existing issues** (20 minutes)
+   * [Issue 326](https://github.com/w3c/webextensions/issues/326): Any plans to implement "tab" context menu? (@bershanskiy)
+     * "Chrome implemented tab context menu context option aligning with Firefox and Safari, so all three engines are in sync now and we might want to close this issue as fixed." ([comment](https://github.com/w3c/webextensions/issues/1053#issuecomment-5240041042))
+   * [Issue 774](https://github.com/w3c/webextensions/issues/774): Inconsistency: contextMenus/Menus (@bershanskiy)
+     * "extensions are still impacted by this incompatibility. Hopefully, we can define desired defaults and introduce console warnings in browsers which would need to adapt." ([comment](https://github.com/w3c/webextensions/issues/1053#issuecomment-5244759725))
+
+
+## Attendees (sign yourself in)
+
+ 1. Rob Wu (Mozilla)
+ 2. Oliver Dunk (Google)
+ 3. Steven McLintock (1Password)
+ 4. Hilary Hacksel (1Password)
+ 5. Simeon Vincent (unaffiliated)
+ 6. Dave Vandyke (DuckDuckGo)
+ 7. Brian Weinstein (Apple)
+ 8. Gaurang Tandon (Text Blaze)
+ 9. Robin Thomas (unaffiliated)
+ 10. Timothy Hatcher (Apple)
+ 11. David Johnson (Apple)
+ 12. Brandon Lucier (1Password)
+ 13. Patrick Kettner (Google)
+ 14. Casey Garland (Fetch)
+ 15. Tomislav Jovanovic (Mozilla)
+ 16. Ben Greenberg (Aglide)
+ 17. Benjamin Bruneau (1Password)
+ 18. Mukul Purohit (Microsoft)
+ 19. Carlos Jeurissen (unaffiliated)
+
+
+## Meeting notes
+
+Announcement: [w3c/tpac2026-meetings#70 (comment)](https://github.com/w3c/tpac2026-meetings/issues/70#issuecomment-5133840941): CG members can't currently register for TPAC
+
+ * [simeon] WECG people are currently unable to sign up to TPAC because the meeting are officially registered through the WEWG. Hopefully the restriction will be lifted.
+
+Announcement: @dotproto published up [webextensions.group](https://webextensions.group/) (repo)
+
+ * [simeon] I created [https://webextensions.group](https://webextensions.group/) as an easier means to access relevant content from our repo and WECG, WEWG groups. Currently a separate repo, but could be made part of our group repo. Feedback and feature requests welcome.
+
+[Issue 1054](https://github.com/w3c/webextensions/issues/1054): Allow extensions to inject content scripts into sandboxed extension pages
+
+ * [robin] I have an extension to make mouse gestures and assign commands to gestures. I have a tutorial page to enable users to try out something at the beginning. Some functionality (scroll up/down) requires a content script. For this tutorial page I either have to preload the relevant code that would be relevant later, or inject them on demand via `scripting.executeScript`. On regular websites it works, but it fails on the tutorial page (e.g. a `moz-extension:`). I was hoping that the manifest `sandbox.pages` feature would enable content scripts to run.
+ * [timothy] So, this is a page that your extension is in complete control of?
+ * [robin] Yes.
+ * [timothy] May be best to preload all necessary scripts.
+ * [robin] I would like to avoid duplicating logic, since most logic is initiated through `scripting.executeScript`.
+ * [rob] I'm familiar with this because I've reviewed patches of yours that improve the Firefox implementation of manifest sandbox. Firefox recently removed executeScript in extension pages. We never really intended for that to work. Did you use that? (robin: yes). Firefox is willing to consider allowing executeScript to work in sandboxed pages. Safari does not have this feature, correct?
+ * [timothy] Correct. Speaking more abstractly that if this is a page you control, you can inject there.
+ * [rob] True, but requires duplication of logic.
+ * [robin] Unsupported case: user scripts in sandboxed pages.
+ * [david] For a tutorial, might make sense to have the tutorial page on your domain. Would also enable onboarding Safari's unique host permissions experience, for example.
+ * [robin] Considered this, but its a lot of work to have a separate server and localization setup for a real website.
+ * [simeon] Also creates challenges for offline access.
+ * [rob] Manifest sandbox enabled packaging all relevant dependencies with the extension, not keen on forcing the use of a remotely hosted page as a work-around.
+ * [rob] Is Chrome open to supporting executeScript in sandboxed documents?
+ * [oliver] How about the `ExecutionWorld` parameter? We don't have the concept of an isolated world in sandboxed pages.
+ * [rob] Could work. All scripts are from the extension. No special capabilities granted. If the extension needs to talk back to itself, could create problems if runtime.sendMessage isn't exposed.
+ * [oliver] Not familiar enough with the implementation, but I imagine this breaks security guarantees we can currently provide by saying sandboxed pages never have access to messaging APIs.
+ * [rob] Right. I can see an issue if an extension relied on `sender.origin` for verification, and a content script could run on an extension document. We probably don't want to allow the isolated world, or we can at least defer that for now.
+ * [rob] Robin, do you need any special functionality?
+ * [robin] I don't think so. Main world should be fine.
+ * [oliver] I can follow up with the team.
+ * [david] This would be limited to content scripts injecting from the same extension, correct?
+ * [rob] Correct, a convenience feature for extensions to do something.
+
+[Issue 1055](https://github.com/w3c/webextensions/issues/1055): Inconsistency: Return value for alarms.clearAll()
+
+ * [timothy] When wpt included tests for alarms API, it highlighted a difference in how browsers behave with `alarms.clearAll`. Chrome unconditionally returns true, Firefox returns whether any alarm was created, and Safari did not return anything (but changed to match Firefox).
+ * [oliver] There are actually 3 options. The two you mentioned, and potentially changing it to return the names of the cleared alarms. Given the current inconsistencies, we thought there may be limited usage of the current return value.
+ * [timothy] Returning all names sounds reasonable.
+ * [brian] Seems like limited value. Clear all makes it clear you don't want any alarms.
+ * [rob] I second that. If extensions really cared, they could invoke `alarms.getAll` if they wanted that information before clearing.
+ * [timothy] And if you have your own tracking dictionary on the side, you'd clear that when you call clearAll.
+ * [dave] Wouldn't a return type of undefined make more sense if no one cares?
+ * [timothy] That's what we were doing until we started working on the WPT tests.
+ * [rob] I'd be okay with dropping the return value.
+ * [rob] It's already not meaningful in Chrome. I haven't run into this difference myself until recently. As a base behavior, I think Firefox's behavior makes the most sense, where we return if any alarm was removed. In Chrome “true” means that the operation succeeded, but resolving vs rejecting is already that signal.
+ * [oliver] My gut feeling is that what Rob is suggesting makes sense. Most of the time if you're clearing alarms you probably had some alarms registered. I'll look into whether we can get some hard data from the ecosystem on potential breakage.
+ * [timothy] If we can prove if devs aren't using it today, I'm in favor of dropping the return value.
+ * [simeon] For clarity, I think Rob and Oliver were suggesting returning true/false.
+ * [timothy] Got it. No strong feeling one way or the other.
+ * [simeon] No strong feeling myself. I'm curious what the prevailing pattern would be in the broader platform. If clear.
+ * [rob] I believe that returning void (undefined) is common. E.g. Map's `delete()` returns whether an entry was deleted, but `clear()` returns `undefined`.
+ * [simeon] Okay, I'll do a survey of the current platform to see what the typical return pattern is and add a comment to the issue.
+
+[Issue 1056](https://github.com/w3c/webextensions/issues/1056): Inconsistency: runtime.getPlatformInfo()
+
+ * [anton] At some point Chrome needed to expose platform-specific files for some extensions. Extensions need to know which files are downloaded, based on architecture, and exposes that information (in `getPlatformInfo`). Proposal is to warn users when (???). Or remove the information entirely.
+ * [rob] I think Chrome is moving towards removing nacl_arch. In Firefox we also offer nacl_arch as an alias for arch. I think some extensions use arch to target the right binary for native messaging. Other than that not too useful except maybe for analytics.
+ * [oliver] As Rob said we're working on removing nacl_arch. Is the desire to align on `arch` values or remove it entirely?
+ * [anton] Remove entirely. In Chromium it exposes the bitness of the browser, not of the operating system.
+ * [oliver] Beyond bitness, could still be useful for deciding if you need arm or intel for native messaging.
+ * [anton] Those cases are covered by web APIs in Chromium.
+   * [simeon] https://developer.mozilla.org/en-US/docs/Web/API/NavigatorUAData/getHighEntropyValues
+   * [rob] That web API is async and has requirements.
+ * [oliver] Don't see a reason to remove it if its working well enough.
+ * [timothy] I'm noticing Safari returns ARM for ARM64.
+ * [simeon] Do you know if it returns the browser or OS's platform?
+ * [timothy] They are the same for our platforms.
+ * [rob] In the meantime, MDN was updated to reflect the current state. I recently reviewed a change.
+   * https://github.com/mdn/content/pull/43847
+ * [timothy] Looks like the PR is a draft. We based our implementation on MDN (https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/PlatformArch).
+ * [rob] Anton, could you propose what to do, since removing doesn't seem supported by browser reps.
+ * [anton] Suggest arm to arm64, or even aarch64.
+ * [timothy] I'd prefer arm64. aarch64 isn't common these days. More of a Linux term. Any browser using arch64?
+ * [anton] Firefox currently returns aarch64.
+ * [patrick] Chrome uses “arm64”.
+ * [rob] Suggest continuing this discussion async on the issue.
+
+[Issue 1058](https://github.com/w3c/webextensions/issues/1058): Inconsistency: proxy.settings
+
+ * [oliver] There is a broader issue ([issue 573](https://github.com/w3c/webextensions/issues/573)), this part is something small that we can do. I think that the request could already be implemented today without additional API changes, by generating a PAC script with the list embedded at the top.
+ * [rob] Could you post your thoughts on the issue?
+ * [oliver] Will do.
+
+[Issue 940](https://github.com/w3c/webextensions/issues/940): Provide a way to distinguish prefetch requests from regular navigations in extension APIs
+
+ * [oliver] We have a feature called “prefetch” where we pre-fetch the initial document (distinct from prerender), which could be a regular cache, or even an in-memory cache, which makes the actual navigation very fast. Link rel prefetch, or speculation rules in a JSON file. Right now we do not consistently identify these in webRequest. documentLifeCycle “active”, resourceType main_frame, etc. Extension devs need to distinguish between actual main_frame vs actual request. Leaning towards “other” type instead of “main_frame” resourceType.
+ * [dave] May be misunderstanding, but why can't they use `webNavigation.onCommitted` to know that the navigation was committed to.
+ * [oliver] In the use case (ad block) they'd like to block the request as early as possible, before the request reaches the server.
+ * [dave] We had something similar in AdBlock Plus a long time ago where we had to watch onHeadersReceived in order to figure out if we thought the navigation was going to be completed. Again, may be misunderstanding, onCommited or simply blocking the main frame request regardless of whether is prefetch seems reasonable.
+ * [oliver] Check and egg problem. If you block in onBeforeSendHeaders, you can see if its prefetch and choose whether to block silently for a prefetch. Or you can use onBeforeNavigate show a warning to the user for a real navigation. Can't really do both.
+ * [rob] Besides main frame or other, are there other approaches you were considering?
+ * [oliver] Could use documentLifecycle, but we normally use that for the status of the page making the request, not for the request being made. Could add a new property (like `prefetchType`). Could have an alternative to `other`.
+ * [rob] I mentioned `speculative` as a resource type in the issue. Thoughts?
+ * [oliver] That would be a new value.
+ * [rob] It is already defined… but currently Firefox only.
+ * [oliver] Ah. If we have something in Firefox and it is used for similar enough situations I think this is reasonable.
+ * [rob] Related, we currently treat view-source as main_frame. For extensions that don't want to show a warning, would also be useful to distinguish.
+ * [oliver] In enterprise extension use case, I don't see the value. I think that view-source may be useful for other extensions.
+ * [rob] Should we discuss that in a separate issue?
+ * [oliver] Do you have other use cases in mind?
+ * [rob] Broad thought is distinguishing between actual navigation and everything else. Specific request in Firefox is https://bugzilla.mozilla.org/show_bug.cgi?id=1683646, with an example of wanting to only redirect actual navigation requests.
+ * [oliver] For view source, would `other` work?
+ * [rob] Probably.
+ * [david] for the sake of time, we'll review the issue internally and comment
+
+[Issue 326](https://github.com/w3c/webextensions/issues/326): Any plans to implement "tab" context menu?
+
+ * "Chrome implemented tab context menu context option aligning with Firefox and Safari, so all three engines are in sync now and we might want to close this issue as fixed." ([comment](https://github.com/w3c/webextensions/issues/1053#issuecomment-5240041042))
+ * [simeon] Sounds like work is done, so we can close.
+ * [david] Would it make sense to add a test before closing?
+ * [timothy] Hard because the test framework does not support interaction with tabs. We could only verify the presence of the enum.
+ * [rob] I think that we can close the issue and create new issues to track building out tests if we want.
+
+[Issue 774](https://github.com/w3c/webextensions/issues/774): Inconsistency: contextMenus/Menus
+
+ * "extensions are still impacted by this incompatibility. Hopefully, we can define desired defaults and introduce console warnin gs in browsers which would need to adapt." ([comment](https://github.com/w3c/webextensions/issues/1053#issuecomment-5244759725))
+ * [simeon] Out of time. We'll take this up at the next meeting.
+
+Announcement: Microsoft Edge announced MV2 deprecation.
+
+ * [mukul] Microsoft Edge announced [Moving the Microsoft Edge extensions ecosystem forward with Manifest Version 3 - Microsoft Edge Blog](https://blogs.windows.com/msedgedev/2026/08/07/moving-the-microsoft-edge-extensions-ecosystem-forward-with-manifest-version-3/)
+
+The next meeting will be on [Thursday, August 27th, 8 AM PDT (3 PM UTC)](https://everytimezone.com/?t=6a90cf80,384).

--- a/_minutes/README.md
+++ b/_minutes/README.md
@@ -15,9 +15,9 @@ After the end of each meeting, meeting notes are published here.
 
 The agenda for upcoming meetings is prepared in [issues with `label:agenda`](https://github.com/w3c/webextensions/issues?q=is%3Aissue%20state%3Aopen%20label%3Aagenda).
 
-- 2026-08-13 at 8 AM PDT = https://everytimezone.com/?t=6a7e5a80,384
 - 2026-08-20 WEWG meeting: https://everytimezone.com/?t=6a879500,384
 - 2026-08-27 at 8 AM PDT = https://everytimezone.com/?t=6a90cf80,384
+- 2026-09-10 at 8 AM PDT = https://everytimezone.com/?t=6aa34480,384
 
 Calendars:
 - https://www.w3.org/groups/cg/webextensions/calendar/ (Community Group)
@@ -25,19 +25,20 @@ Calendars:
 
 ## Past meetings
 
+* 2026-08-13 ([minutes](2026-08-13-wecg.md))
 * 2026-07-30 ([minutes](2026-07-30-wecg.md))
 * 2026-07-23 WEWG meeting ([minutes](2026-07-23-wewg.md))
 * 2026-07-16 ([minutes](2026-07-16-wecg.md))
 * 2026-07-02 ([minutes](2026-07-02-wecg.md))
 * 2026-06-25 WEWG meeting ([minutes](2026-06-25-wewg.md))
 * 2026-06-18 ([minutes](2026-06-18-wecg.md))
-* 2026-06-04 ([minutes](2026-06-04-wecg.md))
 
 <details>
 <summary><strong>All past meeting notes</strong></summary>
 
 **2026**
 
+* 2026-08-13 ([minutes](2026-08-13-wecg.md))
 * 2026-07-30 ([minutes](2026-07-30-wecg.md))
 * 2026-07-23 WEWG meeting ([minutes](2026-07-23-wewg.md))
 * 2026-07-16 ([minutes](2026-07-16-wecg.md))


### PR DESCRIPTION
Generated from https://docs.google.com/document/d/1QkwhEMtMS67JBUkl_WVPZ4lRSKoWcQNlLJSf_GwSXg8/edit using the tool and process from https://github.com/w3c/webextensions/pull/105.

During this meeting we discussed or mentioned issues #1053, #531, #1054, #1055, #1056, #1058, #940, #326, #573. #774 was on the agenda but skipped due to lack of time. 

Microsoft Edge also announced deprecation of MV2, with https://blogs.windows.com/msedgedev/2026/08/07/moving-the-microsoft-edge-extensions-ecosystem-forward-with-manifest-version-3/