### PR TITLE
Publish minutes of 2026-08-20 WEWG meeting

### DIFF
--- a/_minutes/2026-08-20-wewg.md
+++ b/_minutes/2026-08-20-wewg.md
@@ -1,0 +1,105 @@
+# WEWG Meetings 2026, Public Notes—August 20, 2026
+
+ * Chair: Simeon Vincent
+ * Scribes: Rob Wu
+
+Time: 8 AM PDT = https://everytimezone.com/?t=6a879500,384
+Call-in details: [WEWG Calendar](https://www.w3.org/groups/wg/webextensions/calendar/)
+Zoom issues? Ping @zombie (Tomislav Jovanovic) in [chat](https://github.com/w3c/webextensions/blob/main/CONTRIBUTING.md#joining-chat)
+
+
+## Agenda
+
+ * Previous action items
+ * [Issue 1040](https://github.com/w3c/webextensions/issues/1040): Review and Feedback requested: Attribution Level 1 2026-06-29 > 2026-07-29
+ * [PR 1059](https://github.com/w3c/webextensions/pull/1059): Define Browser interface
+ * Next action items
+
+
+## Attendees (sign yourself in)
+
+ 1. Rob Wu (Mozilla)
+ 2. Simeon Vincent (invited expert)
+ 3. Tomislav Jovanovic (Mozilla)
+ 4. Oliver Dunk (Google)
+ 5. David Johnson (Apple)
+ 6. Carlos Jeurissen (invited expert)
+ 7. Devlin Cronin (Google)
+ 8. Mukul Purohit (Microsoft)
+ 9. Jordan Spivack (Capital One)
+
+
+## Meeting notes
+
+Previous action items
+
+ * [rob,devlin,timothy] Review and provide feedback on [PR 1049](https://github.com/w3c/webextensions/pull/1049) (simeon)
+   * [simeon] Thanks for the feedback; I'll apply the feedback and ping you when it is ready for another round.
+ * [simeon] Build out high level spec structure. (group)
+   * [simeon] I did not get to it. I've been distracted the past few weeks. Plan to work on this soon.
+ * [oliver] Add initial draft of Alarms API spec text.
+   * [oliver] Started writing, not specifically alarms yet, but ended up with the Browser API spec as deliverable which is also on today's agenda. Also landed some changes in Chrome, e.g. alarms minimum went from 30 seconds to 1 second.
+   * (...)
+   * [devlin] Docs say not to use this as a clock.
+   * [simeon] Given the smaller window (1 sec), is there an expectation of more reliability for an alarm to fire at a given time?
+   * [oliver] No implementation changes, but should be fairly reliable.
+   * [david] Can it drift?
+   * [oliver] If scheduled to fire every second, we schedule 1 second after the alarm is supposed to fire, so no drift.
+   * [simeon] In the last CG meeting I volunteered to do a survey of how web APIs handle cancelation and clearing. Oliver asked if that would be ready for the next CG meeting. I fully intend to, yes.
+ * [kiara] Update `externally_connectable` PR
+   * [rob] The PR ​​([PR 873](https://github.com/w3c/webextensions/pull/873)) has been updated, approved, and Devlin also posted a review. Expect that it can be merged after a small update.
+ * [tomislav] Look into available wpt infrastructure to preview test changes across browsers (rob)
+   * [tomislav] Didn't get to it. Will carry on this action item for the next meeting.
+
+[Issue 1040](https://github.com/w3c/webextensions/issues/1040): Review and Feedback requested: Attribution Level 1 2026-06-29 > 2026-07-29
+
+ * [simeon] They have formally requested review from us, which we have kicked from the WECG to the WEWG.
+ * [oliver] Happy to take a look.
+ * [rob] What is the relevance between this feature and our group?
+ * [oliver] Feature request to toggle the feature availability from extensions.
+ * [simeon] If you're willing to take on an initial look and bring your impressions to the group, that sounds like it would be extremely useful.
+ * [rob] [“9.2 Disabling the Attribution API”](https://www.w3.org/TR/attribution/#opt-out) already exists, so if there is a desire to disable the feature from extensions (and non-extensions), their spec already provides that option.
+ * [simeon] I think the request may be, we've already carved this out, what's the next steps to getting an extension API? What namespace would we use for something like this?
+ * [devlin] Usually privacy, but possibly others.
+ * [rob] The issue calls out `chrome.privacy.websites.adMeasurementEnabled` as a specific API name, for example (I read `browser.` and `chrome.` here).
+
+[PR 1059](https://github.com/w3c/webextensions/pull/1059): Define Browser interface
+
+ * [oliver] While working on spec text for the alarms API. To do that, we need to declare `alarms` on `browser`. I was looking into ways to do that. Currently the `browser` global is just a reserved name, content is unspecified. I think we may want to use an interface in WebIDL to define this, but one downside is that a lowercase `browser` member would also be accompanied by an uppercase `Browser`. A work-around to that is to use `LegacyNoInterfaceObject`, but that trips up linter issues.
+ * [oliver] Spoke with Dominic Farolino about this limitation. Question is how we want to approach this. One option is to keep the `LegacyNoInterfaceObject`. The other is to try to align browsers on the behavior if we don't use that attribute. Would be easiest from a spec point of view. No need to customize the linting logic, etc.
+ * [tomislav] …
+ * [oliver] Don't know what was changed. One that doesn't make sense is window.Window, which can't be constructed.
+ * [rob] `Window` can be used for type checking, can't imagine that to be useful for the `browser` namespace.
+ * [devlin] `browser` is a plain object. No prototype, no constructor. Could potentially change that, but wouldn't want to block the spec.
+ * [oliver] When this change was made on the web, I don't believe there were backwards compatibility issues.
+ * [devlin] I think web is a little different. I expect that most of them were actually backed by classes. In Chrome historically (I assume Firefox as well), because of how extensions came to be, we were monkey patching properties on a global object. As a result, I expect there is more variation in the structure of the namespaces. I expect there will be things we need to work through, discuss, align on, and it would be best to do this slowly. Don't want to make this blocking to spec efforts.
+ * [oliver] Makes sense.
+ * [tomislav] We should be specifying what exists and where we already align and discuss how we want to change things.
+ * [devlin] There's also a lot of weird stuff with how properties on `browser` work that we probably don't want to specify. In Chrome, properties are lazily populated. We can also remove them in some cases. We don't remove them if the namespace has been modified by the extension.
+ * [oliver] I think there are some cases with the User Scripts API where we don't remove it.
+ * [devlin] All to say what we currently do is weird, and we shouldn't try to force a change to this paradigm.
+ * [oliver] Sounds like we're all aligned that we don't want to make browser changes to match an interface exactly. I was originally going to propose we use `LegacyNoInterfaceObject` and request a toggle to disable this linting check. What's the harm if we don't, though?
+ * [rob] Is there anything inaccurate if we specify it as an interface?
+ * [oliver] It would be inaccurate because we don't have Browser as constructable, but maybe thats acceptable?
+ * [devlin] I'm okay with having it be inaccurate. We can include a note that explicitly says “this isn't actually an interface”.
+ * [oliver] I think we can also link that to an issue that goes into detail about this.
+ * [rob] Since we're talking about `browser`, are we also considering specifying the behavior of revoking permissions can remove properties, etc? Devlin is shaking his head. Is that left to the implementation?
+ * [devlin] If someone is particularly ambitious and someone wants to research and document the common behavior, I'm okay with that. But I don't think we're consistent with our behavior and we likely wouldn't prioritize making changes here. I want to be cognizant of limited resources and not let perfect be the enemy of good.
+ * [oliver] Next steps, I'll move forward on my side by looking into `browser` attributes. Tomislav will on his side as well. We'll keep having an empty interface in the browser spec, and we'll have partial interfaces that we expand in other parts of the spec.
+
+TPAC
+
+ * [rob] We haven't created TPAC issue or wiki resources yet. Anything stopping us from doing that?
+ * [simeon] I'll create it.
+
+Next action items
+
+ * [Assignee] Task (Requester)
+ * [simeon] Build out high level spec structure.
+ * [tomislav] Look into available wpt infrastructure to preview test changes across browsers (rob)
+ * [oliver] Look in review request for Attribution Level 1 ([Issue 1040](https://github.com/w3c/webextensions/issues/1040)).
+ * [oliver] Look into feasibility of empty interface in browser spec
+ * [tomislav] Get confirmation internally on direction of spec (using interface).
+ * [simeon] Create TPAC wiki page and topic proposal issue (rob)
+
+The next WEWG meeting will be on [Thursday, September 17th, 8 AM PDT (3 PM UTC)](https://everytimezone.com/?t=6aac7f00,384).

--- a/_minutes/README.md
+++ b/_minutes/README.md
@@ -15,9 +15,9 @@ After the end of each meeting, meeting notes are published here.
 
 The agenda for upcoming meetings is prepared in [issues with `label:agenda`](https://github.com/w3c/webextensions/issues?q=is%3Aissue%20state%3Aopen%20label%3Aagenda).
 
-- 2026-08-20 WEWG meeting: https://everytimezone.com/?t=6a879500,384
 - 2026-08-27 at 8 AM PDT = https://everytimezone.com/?t=6a90cf80,384
 - 2026-09-10 at 8 AM PDT = https://everytimezone.com/?t=6aa34480,384
+- 2026-09-17 WEWG meeting: https://everytimezone.com/?t=6aac7f00,384
 
 Calendars:
 - https://www.w3.org/groups/cg/webextensions/calendar/ (Community Group)
@@ -25,6 +25,7 @@ Calendars:
 
 ## Past meetings
 
+* 2026-08-20 WEWG meeting ([minutes](2026-08-20-wewg.md))
 * 2026-08-13 ([minutes](2026-08-13-wecg.md))
 * 2026-07-30 ([minutes](2026-07-30-wecg.md))
 * 2026-07-23 WEWG meeting ([minutes](2026-07-23-wewg.md))
@@ -38,6 +39,7 @@ Calendars:
 
 **2026**
 
+* 2026-08-20 WEWG meeting ([minutes](2026-08-20-wewg.md))
 * 2026-08-13 ([minutes](2026-08-13-wecg.md))
 * 2026-07-30 ([minutes](2026-07-30-wecg.md))
 * 2026-07-23 WEWG meeting ([minutes](2026-07-23-wewg.md))


### PR DESCRIPTION
*Generated from https://docs.google.com/document/d/1ezXs4uJzbfi8nyncUQcFLDyS9Tn_trs9j_RQgM54GBE/edit using the tool and process from https://github.com/w3c/webextensions/pull/105 (adapted for the [WebExtensions Working Group](https://www.w3.org/groups/wg/webextensions/) (WEWG)).*

During this meeting we discussed or mentioned issue #1040 and PRs #1059, #1049, #873.

Action items:
 * [simeon] Build out high level spec structure.
 * [tomislav] Look into available wpt infrastructure to preview test changes across browsers (rob)
 * [oliver] Look in review request for Attribution Level 1 ([Issue 1040](https://github.com/w3c/webextensions/issues/1040)).
 * [oliver] Look into feasibility of empty interface in browser spec
 * [tomislav] Get confirmation internally on direction of spec (using interface).
 * [simeon] Create TPAC wiki page and topic proposal issue (rob)